### PR TITLE
Add Z.ai and MiniMax providers

### DIFF
--- a/electron/main/settingsManager.ts
+++ b/electron/main/settingsManager.ts
@@ -11,9 +11,17 @@ export interface AppSettings {
   VITE_OPENAI_PROJECT?: string
   VITE_OPENAI_ASSISTANT_ID?: string
   VITE_OPENROUTER_API_KEY?: string
+  VITE_ZAI_API_KEY?: string
+  VITE_MINIMAX_API_KEY?: string
   VITE_GROQ_API_KEY?: string
   sttProvider?: 'openai' | 'groq' | 'transformers'
-  aiProvider?: 'openai' | 'openrouter' | 'ollama' | 'lm-studio'
+  aiProvider?:
+    | 'openai'
+    | 'openrouter'
+    | 'ollama'
+    | 'lm-studio'
+    | 'zai'
+    | 'minimax'
 
   // Transformers STT settings
   transformersModel?: string
@@ -25,6 +33,8 @@ export interface AppSettings {
 
   ollamaBaseUrl?: string
   lmStudioBaseUrl?: string
+  zaiBaseUrl?: string
+  minimaxBaseUrl?: string
 
   assistantModel?: string
   assistantSystemPrompt?: string

--- a/src/components/settings/AssistantSettingsTab.vue
+++ b/src/components/settings/AssistantSettingsTab.vue
@@ -62,6 +62,12 @@
                 currentSettings.VITE_OPENAI_API_KEY) ||
                 (currentSettings.aiProvider === 'openrouter' &&
                   currentSettings.VITE_OPENROUTER_API_KEY) ||
+                (currentSettings.aiProvider === 'zai' &&
+                  currentSettings.VITE_ZAI_API_KEY &&
+                  currentSettings.zaiBaseUrl) ||
+                (currentSettings.aiProvider === 'minimax' &&
+                  currentSettings.VITE_MINIMAX_API_KEY &&
+                  currentSettings.minimaxBaseUrl) ||
                 (currentSettings.aiProvider === 'ollama' &&
                   currentSettings.ollamaBaseUrl) ||
                 (currentSettings.aiProvider === 'lm-studio' &&
@@ -293,15 +299,24 @@
               ((currentSettings.aiProvider === 'openai' &&
                 currentSettings.VITE_OPENAI_API_KEY) ||
                 (currentSettings.aiProvider === 'openrouter' &&
-                  currentSettings.VITE_OPENROUTER_API_KEY)) &&
+                  currentSettings.VITE_OPENROUTER_API_KEY) ||
+                (currentSettings.aiProvider === 'zai' &&
+                  currentSettings.VITE_ZAI_API_KEY &&
+                  currentSettings.zaiBaseUrl) ||
+                (currentSettings.aiProvider === 'minimax' &&
+                  currentSettings.VITE_MINIMAX_API_KEY &&
+                  currentSettings.minimaxBaseUrl) ||
+                (currentSettings.aiProvider === 'ollama' &&
+                  currentSettings.ollamaBaseUrl) ||
+                (currentSettings.aiProvider === 'lm-studio' &&
+                  currentSettings.lmStudioBaseUrl)) &&
               availableModels.length === 0
             "
             class="text-xs text-warning mt-1"
           >
-            {{
-              currentSettings.aiProvider === 'openai' ? 'OpenAI' : 'OpenRouter'
-            }}
-            API key needs to be validated (Save & Test) to load models.
+            {{ getProviderDisplayName(currentSettings.aiProvider) }}
+            API key/configuration needs to be validated (Save & Test) to load
+            models.
           </p>
           <p class="text-xs text-gray-400 mt-1">
             Model used for generating conversation summaries (e.g.,
@@ -360,9 +375,7 @@
                   class="checkbox checkbox-accent checkbox-sm"
                   :disabled="!isToolConfigured(tool.name)"
                 />
-                <span
-                  class="label-text font-bold text-white"
-                >
+                <span class="label-text font-bold text-white">
                   {{ tool.displayName }}
                   <span
                     v-if="!isToolConfigured(tool.name)"
@@ -374,7 +387,10 @@
               </label>
               <div class="text-sm text-gray-400">
                 {{ tool.description }}
-                <template v-if="!isToolConfigured(tool.name)">(API key for this tool not configured in Optional Tool APIs section)</template>
+                <template v-if="!isToolConfigured(tool.name)"
+                  >(API key for this tool not configured in Optional Tool APIs
+                  section)</template
+                >
               </div>
             </div>
           </div>
@@ -412,10 +428,7 @@
                 >
                   {{ tool.enabled ? 'enabled' : 'disabled' }}
                 </span>
-                <span
-                  v-if="!tool.isValid"
-                  class="text-warning font-semibold"
-                >
+                <span v-if="!tool.isValid" class="text-warning font-semibold">
                   needs fix
                 </span>
               </li>
@@ -505,6 +518,8 @@ const getProviderDisplayName = (provider: string): string => {
     openrouter: 'OpenRouter',
     ollama: 'Ollama',
     'lm-studio': 'LM Studio',
+    zai: 'Z.ai',
+    minimax: 'MiniMax',
   }
   return providerNames[provider] || provider
 }

--- a/src/components/settings/CoreSettingsTab.vue
+++ b/src/components/settings/CoreSettingsTab.vue
@@ -19,6 +19,8 @@
           >
             <option value="openai">OpenAI</option>
             <option value="openrouter">OpenRouter</option>
+            <option value="zai">Z.ai (Coding Plan)</option>
+            <option value="minimax">MiniMax</option>
             <option value="ollama">Ollama (Local)</option>
             <option value="lm-studio">LM Studio (Local)</option>
           </select>
@@ -133,6 +135,66 @@
           />
           <p class="text-xs text-gray-400 mt-1">
             URL where your Ollama server is running.
+          </p>
+        </div>
+        <div v-if="currentSettings.aiProvider === 'zai'">
+          <label for="zai-key" class="block mb-1 text-sm">Z.ai API Key *</label>
+          <input
+            id="zai-key"
+            type="password"
+            v-model="currentSettings.VITE_ZAI_API_KEY"
+            class="input focus:outline-none w-full"
+            autocomplete="new-password"
+            placeholder="..."
+          />
+          <p class="text-xs text-gray-400 mt-1">
+            Required for GLM Coding Plan chat models.
+          </p>
+        </div>
+        <div v-if="currentSettings.aiProvider === 'zai'">
+          <label for="zai-url" class="block mb-1 text-sm"
+            >Z.ai Base URL *</label
+          >
+          <input
+            id="zai-url"
+            type="text"
+            v-model="currentSettings.zaiBaseUrl"
+            class="input focus:outline-none w-full"
+            placeholder="https://api.z.ai/api/coding/paas/v4"
+          />
+          <p class="text-xs text-gray-400 mt-1">
+            Coding Plan endpoint for OpenAI-compatible tools.
+          </p>
+        </div>
+        <div v-if="currentSettings.aiProvider === 'minimax'">
+          <label for="minimax-key" class="block mb-1 text-sm"
+            >MiniMax API Key *</label
+          >
+          <input
+            id="minimax-key"
+            type="password"
+            v-model="currentSettings.VITE_MINIMAX_API_KEY"
+            class="input focus:outline-none w-full"
+            autocomplete="new-password"
+            placeholder="..."
+          />
+          <p class="text-xs text-gray-400 mt-1">
+            Required for MiniMax OpenAI-compatible chat models.
+          </p>
+        </div>
+        <div v-if="currentSettings.aiProvider === 'minimax'">
+          <label for="minimax-url" class="block mb-1 text-sm"
+            >MiniMax Base URL *</label
+          >
+          <input
+            id="minimax-url"
+            type="text"
+            v-model="currentSettings.minimaxBaseUrl"
+            class="input focus:outline-none w-full"
+            placeholder="https://api.minimax.io/v1"
+          />
+          <p class="text-xs text-gray-400 mt-1">
+            OpenAI-compatible endpoint for MiniMax token/coding plans.
           </p>
         </div>
         <div v-if="currentSettings.aiProvider === 'lm-studio'">

--- a/src/components/wizard/OnboardingWizard.vue
+++ b/src/components/wizard/OnboardingWizard.vue
@@ -16,6 +16,8 @@
           :is-testing="isTesting"
           @test-openai="testOpenAIKey"
           @test-openrouter="testOpenRouterKey"
+          @test-zai="testZAIKey"
+          @test-minimax="testMiniMaxKey"
           @test-ollama="testOllamaConnection"
           @test-lmstudio="testLMStudioConnection"
           @reset-tests="resetTestResults"
@@ -57,6 +59,11 @@ import AIProviderStep from './steps/AIProviderStep.vue'
 import VoiceModelsStep from './steps/VoiceModelsStep.vue'
 import FinalSetupStep from './steps/FinalSetupStep.vue'
 import OpenAI from 'openai'
+import {
+  MINIMAX_OPENAI_BASE_URL,
+  ZAI_CODING_BASE_URL,
+  type AIProviderKey,
+} from '../../services/llmProviders/providerCatalog'
 
 const step = ref(1)
 const settingsStore = useSettingsStore()
@@ -65,7 +72,9 @@ const scrollContainer = ref<HTMLElement>()
 const formData = reactive({
   VITE_OPENAI_API_KEY: '',
   VITE_OPENROUTER_API_KEY: '',
-  aiProvider: 'openai' as 'openai' | 'openrouter' | 'ollama' | 'lm-studio',
+  VITE_ZAI_API_KEY: '',
+  VITE_MINIMAX_API_KEY: '',
+  aiProvider: 'openai' as AIProviderKey,
   assistantModel: 'gpt-4o-mini' as string,
   summarizationModel: 'gpt-4o-mini' as string,
   sttProvider: 'openai' as 'openai' | 'groq' | 'google' | 'local',
@@ -75,6 +84,8 @@ const formData = reactive({
   VITE_GOOGLE_API_KEY: '',
   ollamaBaseUrl: 'http://localhost:11434',
   lmStudioBaseUrl: 'http://localhost:1234',
+  zaiBaseUrl: ZAI_CODING_BASE_URL,
+  minimaxBaseUrl: MINIMAX_OPENAI_BASE_URL,
   useLocalModels: false,
   availableModels: [] as string[],
   localSttLanguage: 'auto',
@@ -83,6 +94,8 @@ const formData = reactive({
 const isTesting = reactive({
   openai: false,
   openrouter: false,
+  zai: false,
+  minimax: false,
   ollama: false,
   lmStudio: false,
 })
@@ -90,6 +103,8 @@ const isTesting = reactive({
 const testResult = reactive({
   openai: { success: false, error: '' },
   openrouter: { success: false, error: '' },
+  zai: { success: false, error: '' },
+  minimax: { success: false, error: '' },
   ollama: { success: false, error: '' },
   lmStudio: { success: false, error: '' },
 })
@@ -119,7 +134,9 @@ const canContinue = computed(() => {
       if (
         (formData.aiProvider === 'ollama' ||
           formData.aiProvider === 'lm-studio' ||
-          formData.aiProvider === 'openrouter') &&
+          formData.aiProvider === 'openrouter' ||
+          formData.aiProvider === 'zai' ||
+          formData.aiProvider === 'minimax') &&
         !formData.VITE_OPENAI_API_KEY.trim()
       ) {
         return false
@@ -173,6 +190,12 @@ watch(
     if (newProvider === 'openai' || newProvider === 'openrouter') {
       formData.assistantModel = 'gpt-4o-mini'
       formData.summarizationModel = 'gpt-4o-mini'
+    } else if (newProvider === 'zai') {
+      formData.assistantModel = 'glm-5.1'
+      formData.summarizationModel = 'glm-5.1'
+    } else if (newProvider === 'minimax') {
+      formData.assistantModel = 'MiniMax-M2.7'
+      formData.summarizationModel = 'MiniMax-M2.7'
     }
   }
 )
@@ -184,12 +207,21 @@ const fetchAvailableModels = async () => {
       baseURL = `${formData.ollamaBaseUrl}/v1`
     } else if (formData.aiProvider === 'lm-studio') {
       baseURL = `${formData.lmStudioBaseUrl}/v1`
+    } else if (formData.aiProvider === 'zai') {
+      baseURL = formData.zaiBaseUrl
+    } else if (formData.aiProvider === 'minimax') {
+      baseURL = formData.minimaxBaseUrl
     } else {
       return
     }
 
     const tempClient = new OpenAI({
-      apiKey: formData.aiProvider,
+      apiKey:
+        formData.aiProvider === 'zai'
+          ? formData.VITE_ZAI_API_KEY
+          : formData.aiProvider === 'minimax'
+            ? formData.VITE_MINIMAX_API_KEY
+            : formData.aiProvider,
       baseURL,
       dangerouslyAllowBrowser: true,
     })
@@ -268,6 +300,88 @@ const testOpenRouterKey = async () => {
     }
   } finally {
     isTesting.openrouter = false
+  }
+}
+
+const testZAIKey = async () => {
+  if (!formData.VITE_ZAI_API_KEY.trim()) {
+    testResult.zai.error = 'API Key cannot be empty.'
+    testResult.zai.success = false
+    return
+  }
+  if (!formData.zaiBaseUrl.trim()) {
+    testResult.zai.error = 'Base URL cannot be empty.'
+    testResult.zai.success = false
+    return
+  }
+
+  isTesting.zai = true
+  testResult.zai.error = ''
+  testResult.zai.success = false
+
+  try {
+    const tempClient = new OpenAI({
+      apiKey: formData.VITE_ZAI_API_KEY,
+      baseURL: formData.zaiBaseUrl,
+      dangerouslyAllowBrowser: true,
+      timeout: 10 * 1000,
+      maxRetries: 1,
+    })
+
+    await tempClient.models.list()
+    testResult.zai.success = true
+    await fetchAvailableModels()
+  } catch (e: any) {
+    testResult.zai.error =
+      'API key or Coding Plan endpoint is invalid or has no permissions.'
+    if (e.message?.includes('401')) {
+      testResult.zai.error = 'Invalid API key - please check your key.'
+    } else if (e.message?.includes('429')) {
+      testResult.zai.error = 'Rate limit exceeded - please try again later.'
+    }
+  } finally {
+    isTesting.zai = false
+  }
+}
+
+const testMiniMaxKey = async () => {
+  if (!formData.VITE_MINIMAX_API_KEY.trim()) {
+    testResult.minimax.error = 'API Key cannot be empty.'
+    testResult.minimax.success = false
+    return
+  }
+  if (!formData.minimaxBaseUrl.trim()) {
+    testResult.minimax.error = 'Base URL cannot be empty.'
+    testResult.minimax.success = false
+    return
+  }
+
+  isTesting.minimax = true
+  testResult.minimax.error = ''
+  testResult.minimax.success = false
+
+  try {
+    const tempClient = new OpenAI({
+      apiKey: formData.VITE_MINIMAX_API_KEY,
+      baseURL: formData.minimaxBaseUrl,
+      dangerouslyAllowBrowser: true,
+      timeout: 10 * 1000,
+      maxRetries: 1,
+    })
+
+    await tempClient.models.list()
+    testResult.minimax.success = true
+    await fetchAvailableModels()
+  } catch (e: any) {
+    testResult.minimax.error =
+      'API key or OpenAI-compatible endpoint is invalid or has no permissions.'
+    if (e.message?.includes('401')) {
+      testResult.minimax.error = 'Invalid API key - please check your key.'
+    } else if (e.message?.includes('429')) {
+      testResult.minimax.error = 'Rate limit exceeded - please try again later.'
+    }
+  } finally {
+    isTesting.minimax = false
   }
 }
 
@@ -352,6 +466,10 @@ const resetTestResults = () => {
   testResult.openai.error = ''
   testResult.openrouter.success = false
   testResult.openrouter.error = ''
+  testResult.zai.success = false
+  testResult.zai.error = ''
+  testResult.minimax.success = false
+  testResult.minimax.error = ''
   testResult.ollama.success = false
   testResult.ollama.error = ''
   testResult.lmStudio.success = false
@@ -363,6 +481,18 @@ const isCurrentProviderTested = () => {
     return testResult.openai.success
   } else if (formData.aiProvider === 'openrouter') {
     return testResult.openrouter.success
+  } else if (formData.aiProvider === 'zai') {
+    return (
+      testResult.zai.success &&
+      Boolean(formData.assistantModel) &&
+      Boolean(formData.summarizationModel)
+    )
+  } else if (formData.aiProvider === 'minimax') {
+    return (
+      testResult.minimax.success &&
+      Boolean(formData.assistantModel) &&
+      Boolean(formData.summarizationModel)
+    )
   } else if (formData.aiProvider === 'ollama') {
     return (
       testResult.ollama.success &&

--- a/src/components/wizard/steps/AIProviderStep.vue
+++ b/src/components/wizard/steps/AIProviderStep.vue
@@ -21,6 +21,8 @@
         <option value="openrouter">
           OpenRouter (400+ models, no image gen)
         </option>
+        <option value="zai">Z.ai (GLM Coding Plan)</option>
+        <option value="minimax">MiniMax (OpenAI-compatible)</option>
         <option value="ollama">Ollama (Local LLMs)</option>
         <option value="lm-studio">LM Studio (Local LLMs)</option>
       </select>
@@ -156,6 +158,232 @@
       </button>
 
       <TestResult :result="testResult.openrouter" />
+    </div>
+
+    <!-- Z.ai Configuration -->
+    <div v-else-if="formData.aiProvider === 'zai'" class="space-y-4">
+      <div class="alert alert-info text-sm">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          class="stroke-current shrink-0 w-5 h-5"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+          ></path>
+        </svg>
+        <span
+          >Z.ai uses the GLM Coding Plan OpenAI-compatible endpoint. Web search
+          can still run through Alice tools if configured.</span
+        >
+      </div>
+
+      <div class="form-control">
+        <label class="label">
+          <span class="label-text">Z.ai API Key</span>
+        </label>
+        <input
+          type="password"
+          v-model="formData.VITE_ZAI_API_KEY"
+          placeholder="..."
+          class="input input-bordered w-full focus:input-primary"
+          :class="{
+            'input-error': testResult.zai.error && !testResult.zai.success,
+          }"
+        />
+      </div>
+
+      <div class="form-control">
+        <label class="label">
+          <span class="label-text">Z.ai Base URL</span>
+        </label>
+        <input
+          type="text"
+          v-model="formData.zaiBaseUrl"
+          placeholder="https://api.z.ai/api/coding/paas/v4"
+          class="input input-bordered w-full focus:input-primary"
+          :class="{
+            'input-error': testResult.zai.error && !testResult.zai.success,
+          }"
+        />
+      </div>
+
+      <button
+        @click="$emit('test-zai')"
+        class="btn btn-secondary w-full"
+        :disabled="
+          isTesting.zai ||
+          !formData.VITE_ZAI_API_KEY.trim() ||
+          !formData.zaiBaseUrl.trim()
+        "
+      >
+        <span
+          v-if="isTesting.zai"
+          class="loading loading-spinner loading-xs mr-2"
+        ></span>
+        Test Z.ai Key
+      </button>
+
+      <TestResult :result="testResult.zai" />
+
+      <div
+        v-if="testResult.zai.success && formData.availableModels.length > 0"
+        class="space-y-4"
+      >
+        <div class="form-control">
+          <label class="label">
+            <span class="label-text">Assistant Model</span>
+          </label>
+          <select
+            v-model="formData.assistantModel"
+            class="select select-bordered w-full focus:select-primary focus:outline-none"
+          >
+            <option
+              v-for="model in formData.availableModels"
+              :key="model"
+              :value="model"
+            >
+              {{ model }}
+            </option>
+          </select>
+        </div>
+
+        <div class="form-control">
+          <label class="label">
+            <span class="label-text">Summarization Model</span>
+          </label>
+          <select
+            v-model="formData.summarizationModel"
+            class="select select-bordered w-full focus:select-primary focus:outline-none"
+          >
+            <option
+              v-for="model in formData.availableModels"
+              :key="model"
+              :value="model"
+            >
+              {{ model }}
+            </option>
+          </select>
+        </div>
+      </div>
+    </div>
+
+    <!-- MiniMax Configuration -->
+    <div v-else-if="formData.aiProvider === 'minimax'" class="space-y-4">
+      <div class="alert alert-info text-sm">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          class="stroke-current shrink-0 w-5 h-5"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+          ></path>
+        </svg>
+        <span
+          >MiniMax uses the OpenAI-compatible endpoint for token/coding plans.
+          Web search can still run through Alice tools if configured.</span
+        >
+      </div>
+
+      <div class="form-control">
+        <label class="label">
+          <span class="label-text">MiniMax API Key</span>
+        </label>
+        <input
+          type="password"
+          v-model="formData.VITE_MINIMAX_API_KEY"
+          placeholder="..."
+          class="input input-bordered w-full focus:input-primary"
+          :class="{
+            'input-error':
+              testResult.minimax.error && !testResult.minimax.success,
+          }"
+        />
+      </div>
+
+      <div class="form-control">
+        <label class="label">
+          <span class="label-text">MiniMax Base URL</span>
+        </label>
+        <input
+          type="text"
+          v-model="formData.minimaxBaseUrl"
+          placeholder="https://api.minimax.io/v1"
+          class="input input-bordered w-full focus:input-primary"
+          :class="{
+            'input-error':
+              testResult.minimax.error && !testResult.minimax.success,
+          }"
+        />
+      </div>
+
+      <button
+        @click="$emit('test-minimax')"
+        class="btn btn-secondary w-full"
+        :disabled="
+          isTesting.minimax ||
+          !formData.VITE_MINIMAX_API_KEY.trim() ||
+          !formData.minimaxBaseUrl.trim()
+        "
+      >
+        <span
+          v-if="isTesting.minimax"
+          class="loading loading-spinner loading-xs mr-2"
+        ></span>
+        Test MiniMax Key
+      </button>
+
+      <TestResult :result="testResult.minimax" />
+
+      <div
+        v-if="testResult.minimax.success && formData.availableModels.length > 0"
+        class="space-y-4"
+      >
+        <div class="form-control">
+          <label class="label">
+            <span class="label-text">Assistant Model</span>
+          </label>
+          <select
+            v-model="formData.assistantModel"
+            class="select select-bordered w-full focus:select-primary focus:outline-none"
+          >
+            <option
+              v-for="model in formData.availableModels"
+              :key="model"
+              :value="model"
+            >
+              {{ model }}
+            </option>
+          </select>
+        </div>
+
+        <div class="form-control">
+          <label class="label">
+            <span class="label-text">Summarization Model</span>
+          </label>
+          <select
+            v-model="formData.summarizationModel"
+            class="select select-bordered w-full focus:select-primary focus:outline-none"
+          >
+            <option
+              v-for="model in formData.availableModels"
+              :key="model"
+              :value="model"
+            >
+              {{ model }}
+            </option>
+          </select>
+        </div>
+      </div>
     </div>
 
     <!-- Ollama Configuration -->
@@ -364,6 +592,8 @@ defineProps<{
 defineEmits<{
   'test-openai': []
   'test-openrouter': []
+  'test-zai': []
+  'test-minimax': []
   'test-ollama': []
   'test-lmstudio': []
   'reset-tests': []

--- a/src/components/wizard/steps/VoiceModelsStep.vue
+++ b/src/components/wizard/steps/VoiceModelsStep.vue
@@ -226,7 +226,9 @@
           v-if="
             (formData.aiProvider === 'ollama' ||
               formData.aiProvider === 'lm-studio' ||
-              formData.aiProvider === 'openrouter') &&
+              formData.aiProvider === 'openrouter' ||
+              formData.aiProvider === 'zai' ||
+              formData.aiProvider === 'minimax') &&
             !formData.VITE_OPENAI_API_KEY?.trim()
           "
           class="alert alert-warning text-sm"
@@ -275,7 +277,9 @@
           v-if="
             formData.aiProvider === 'ollama' ||
             formData.aiProvider === 'lm-studio' ||
-            formData.aiProvider === 'openrouter'
+            formData.aiProvider === 'openrouter' ||
+            formData.aiProvider === 'zai' ||
+            formData.aiProvider === 'minimax'
           "
           class="form-control"
         >

--- a/src/modules/conversation/apiInputBuilder.ts
+++ b/src/modules/conversation/apiInputBuilder.ts
@@ -1,5 +1,6 @@
 import type OpenAI from 'openai'
 import type { AppChatMessageContentPart } from '../../types/chat'
+import { isChatCompletionsProvider } from '../../services/llmProviders/providerCatalog'
 
 export type ConversationHistoryRole =
   | 'user'
@@ -35,9 +36,9 @@ export function createApiInputBuilder(
   dependencies: ApiInputBuilderDependencies
 ): ApiInputBuilder {
   return {
-    async build({ isNewChain }): Promise<
-      OpenAI.Responses.Request.InputItemLike[]
-    > {
+    async build({
+      isNewChain,
+    }): Promise<OpenAI.Responses.Request.InputItemLike[]> {
       // `isNewChain` currently does not affect construction but kept for parity.
       void isNewChain
 
@@ -78,10 +79,7 @@ export function createApiInputBuilder(
             ],
           }
         } else {
-          const currentApiRole = msg.role as
-            | 'user'
-            | 'assistant'
-            | 'developer'
+          const currentApiRole = msg.role as 'user' | 'assistant' | 'developer'
           apiItemPartial = { role: currentApiRole, content: [] }
           if (msg.name) apiItemPartial.name = msg.name
 
@@ -182,7 +180,7 @@ export function createApiInputBuilder(
           if (
             currentApiRole === 'assistant' &&
             msg.tool_calls &&
-            aiProvider === 'openrouter'
+            isChatCompletionsProvider(aiProvider)
           ) {
             apiItemPartial.tool_calls = msg.tool_calls
           }
@@ -195,4 +193,3 @@ export function createApiInputBuilder(
     },
   }
 }
-

--- a/src/modules/conversation/backendService.ts
+++ b/src/modules/conversation/backendService.ts
@@ -7,8 +7,12 @@ export interface BackendServiceDependencies {
     assistantSystemPrompt: string
     VITE_OPENAI_API_KEY?: string
     VITE_OPENROUTER_API_KEY?: string
+    VITE_ZAI_API_KEY?: string
+    VITE_MINIMAX_API_KEY?: string
     ollamaBaseUrl?: string
     lmStudioBaseUrl?: string
+    zaiBaseUrl?: string
+    minimaxBaseUrl?: string
   }
   setStatusMessage(message: string): void
   fetchOpenAIModels(): Promise<any[]>
@@ -72,6 +76,22 @@ export function createBackendService(
       deps.logInfo('Cannot fetch models: OpenRouter API Key is missing.')
       return
     }
+    if (provider === 'zai' && !config.VITE_ZAI_API_KEY) {
+      deps.logInfo('Cannot fetch models: Z.ai API Key is missing.')
+      return
+    }
+    if (provider === 'zai' && !config.zaiBaseUrl) {
+      deps.logInfo('Cannot fetch models: Z.ai Base URL is missing.')
+      return
+    }
+    if (provider === 'minimax' && !config.VITE_MINIMAX_API_KEY) {
+      deps.logInfo('Cannot fetch models: MiniMax API Key is missing.')
+      return
+    }
+    if (provider === 'minimax' && !config.minimaxBaseUrl) {
+      deps.logInfo('Cannot fetch models: MiniMax Base URL is missing.')
+      return
+    }
     if (provider === 'ollama' && !config.ollamaBaseUrl) {
       deps.logInfo('Cannot fetch models: Ollama Base URL is missing.')
       return
@@ -90,6 +110,8 @@ export function createBackendService(
         openrouter: 'OpenRouter',
         ollama: 'Ollama',
         'lm-studio': 'LM Studio',
+        zai: 'Z.ai',
+        minimax: 'MiniMax',
       }
       const providerName = providerNameMap[provider] || provider
       deps.setStatusMessage(`Error: Could not fetch ${providerName} models.`)
@@ -102,4 +124,3 @@ export function createBackendService(
     fetchModels,
   }
 }
-

--- a/src/services/apiClients.ts
+++ b/src/services/apiClients.ts
@@ -2,12 +2,18 @@ import OpenAI from 'openai'
 import Groq from 'groq-sdk'
 import { useSettingsStore } from '../stores/settingsStore'
 import { backendApi } from './backendApi'
+import {
+  MINIMAX_OPENAI_BASE_URL,
+  ZAI_CODING_BASE_URL,
+} from './llmProviders/providerCatalog'
 
 let openaiClient: OpenAI | null = null
 let openrouterClient: OpenAI | null = null
 let groqClient: Groq | null = null
 let ollamaClient: OpenAI | null = null
 let lmStudioClient: OpenAI | null = null
+let zaiClient: OpenAI | null = null
+let minimaxClient: OpenAI | null = null
 
 export function getOpenAIClient(): OpenAI {
   if (!openaiClient) {
@@ -57,6 +63,26 @@ export function getLMStudioClient(): OpenAI {
     throw new Error('LM Studio client could not be initialized')
   }
   return lmStudioClient
+}
+
+export function getZAIClient(): OpenAI {
+  if (!zaiClient) {
+    initializeZAIClient()
+  }
+  if (!zaiClient) {
+    throw new Error('Z.ai client could not be initialized')
+  }
+  return zaiClient
+}
+
+export function getMiniMaxClient(): OpenAI {
+  if (!minimaxClient) {
+    initializeMiniMaxClient()
+  }
+  if (!minimaxClient) {
+    throw new Error('MiniMax client could not be initialized')
+  }
+  return minimaxClient
 }
 
 function initializeOpenAIClient(): void {
@@ -140,6 +166,38 @@ function initializeLMStudioClient(): void {
   })
 }
 
+function initializeZAIClient(): void {
+  const settings = useSettingsStore().config
+  if (!settings.VITE_ZAI_API_KEY) {
+    console.error('Z.ai API Key is not configured.')
+    throw new Error('Z.ai API Key is not configured.')
+  }
+
+  zaiClient = new OpenAI({
+    apiKey: settings.VITE_ZAI_API_KEY,
+    baseURL: settings.zaiBaseUrl || ZAI_CODING_BASE_URL,
+    dangerouslyAllowBrowser: true,
+    timeout: 20 * 1000,
+    maxRetries: 1,
+  })
+}
+
+function initializeMiniMaxClient(): void {
+  const settings = useSettingsStore().config
+  if (!settings.VITE_MINIMAX_API_KEY) {
+    console.error('MiniMax API Key is not configured.')
+    throw new Error('MiniMax API Key is not configured.')
+  }
+
+  minimaxClient = new OpenAI({
+    apiKey: settings.VITE_MINIMAX_API_KEY,
+    baseURL: settings.minimaxBaseUrl || MINIMAX_OPENAI_BASE_URL,
+    dangerouslyAllowBrowser: true,
+    timeout: 20 * 1000,
+    maxRetries: 1,
+  })
+}
+
 export function reinitializeClients(): void {
   console.log('Reinitializing API clients with updated settings...')
 
@@ -181,6 +239,22 @@ export function reinitializeClients(): void {
   } catch (error) {
     console.error('Failed to reinitialize LM Studio client:', error)
     lmStudioClient = null
+  }
+
+  try {
+    initializeZAIClient()
+    console.log('Z.ai client reinitialized successfully')
+  } catch (error) {
+    console.error('Failed to reinitialize Z.ai client:', error)
+    zaiClient = null
+  }
+
+  try {
+    initializeMiniMaxClient()
+    console.log('MiniMax client reinitialized successfully')
+  } catch (error) {
+    console.error('Failed to reinitialize MiniMax client:', error)
+    minimaxClient = null
   }
 }
 

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -7,6 +7,8 @@ import {
   getGroqClient,
   getOllamaClient,
   getLMStudioClient,
+  getZAIClient,
+  getMiniMaxClient,
 } from './apiClients'
 import {
   createOpenAIResponse as createOpenAIResponseWithOpenAI,
@@ -21,6 +23,12 @@ import {
   createLMStudioResponse,
   listLMStudioModels,
 } from './llmProviders/lmStudio'
+import { createZAIResponse, listZAIModels } from './llmProviders/zai'
+import {
+  createMiniMaxResponse,
+  listMiniMaxModels,
+} from './llmProviders/minimax'
+import { isChatCompletionsProvider } from './llmProviders/providerCatalog'
 import type { AppChatMessageContentPart } from '../types/chat'
 import type { RagSearchResult } from '../types/rag'
 
@@ -89,6 +97,10 @@ function getAIClient(): OpenAI {
       return getOllamaClient()
     case 'lm-studio':
       return getLMStudioClient()
+    case 'zai':
+      return getZAIClient()
+    case 'minimax':
+      return getMiniMaxClient()
     default:
       return getOpenAIClient()
   }
@@ -104,6 +116,12 @@ export const fetchOpenAIModels = async (): Promise<OpenAI.Models.Model[]> => {
   }
   if (settings.aiProvider === 'lm-studio') {
     return listLMStudioModels()
+  }
+  if (settings.aiProvider === 'zai') {
+    return listZAIModels()
+  }
+  if (settings.aiProvider === 'minimax') {
+    return listMiniMaxModels()
   }
   return listOpenAIModels()
 }
@@ -137,6 +155,24 @@ export const createOpenAIResponse = async (
   }
   if (settings.aiProvider === 'lm-studio') {
     return createLMStudioResponse(
+      input,
+      previousResponseId,
+      stream,
+      customInstructions,
+      signal
+    )
+  }
+  if (settings.aiProvider === 'zai') {
+    return createZAIResponse(
+      input,
+      previousResponseId,
+      stream,
+      customInstructions,
+      signal
+    )
+  }
+  if (settings.aiProvider === 'minimax') {
+    return createMiniMaxResponse(
       input,
       previousResponseId,
       stream,
@@ -678,11 +714,7 @@ export const createSummarizationResponse = async (
     .map(msg => `${msg.role}: ${msg.content}`)
     .join('\n\n')
 
-  if (
-    settings.aiProvider === 'openrouter' ||
-    settings.aiProvider === 'ollama' ||
-    settings.aiProvider === 'lm-studio'
-  ) {
+  if (isChatCompletionsProvider(settings.aiProvider)) {
     const response = await client.chat.completions.create({
       model: summarizationModel,
       messages: [
@@ -734,11 +766,7 @@ export const createContextAnalysisResponse = async (
     .map(msg => `${msg.role}: ${msg.content}`)
     .join('\n\n')
 
-  if (
-    settings.aiProvider === 'openrouter' ||
-    settings.aiProvider === 'ollama' ||
-    settings.aiProvider === 'lm-studio'
-  ) {
+  if (isChatCompletionsProvider(settings.aiProvider)) {
     const response = await client.chat.completions.create({
       model: analysisModel,
       messages: [

--- a/src/services/llmProviders/index.ts
+++ b/src/services/llmProviders/index.ts
@@ -1,6 +1,7 @@
 import { useSettingsStore } from '../../stores/settingsStore'
+import type { AIProviderKey } from './providerCatalog'
 
-export type ProviderKey = 'openai' | 'openrouter' | 'ollama' | 'lm-studio'
+export type ProviderKey = AIProviderKey
 
 export function getProviderKey(): ProviderKey {
   return useSettingsStore().config.aiProvider as ProviderKey

--- a/src/services/llmProviders/minimax.ts
+++ b/src/services/llmProviders/minimax.ts
@@ -1,0 +1,27 @@
+import type OpenAI from 'openai'
+import { getMiniMaxClient } from '../apiClients'
+import {
+  createOpenAICompatibleResponse,
+  listOpenAICompatibleModels,
+} from './openAICompatible'
+
+export const listMiniMaxModels = async (): Promise<OpenAI.Models.Model[]> => {
+  return listOpenAICompatibleModels(getMiniMaxClient)
+}
+
+export const createMiniMaxResponse = async (
+  input: OpenAI.Responses.Request.InputItemLike[],
+  _previousResponseId: string | null,
+  stream: boolean = false,
+  customInstructions?: string,
+  signal?: AbortSignal
+): Promise<any> => {
+  return createOpenAICompatibleResponse(
+    'minimax',
+    getMiniMaxClient,
+    input,
+    stream,
+    customInstructions,
+    signal
+  )
+}

--- a/src/services/llmProviders/openAICompatible.ts
+++ b/src/services/llmProviders/openAICompatible.ts
@@ -1,0 +1,209 @@
+import type OpenAI from 'openai'
+import { useSettingsStore } from '../../stores/settingsStore'
+import { convertLocalLLMStreamToResponsesFormat } from './streamAdapters'
+import { buildToolsForProvider } from './tools'
+import { PROVIDER_CONFIGS } from './providerCatalog'
+
+type OpenAIClientGetter = () => OpenAI
+type OpenAICompatibleProviderKey = 'zai' | 'minimax'
+
+function convertResponsesInputToChatMessages(
+  input: OpenAI.Responses.Request.InputItemLike[]
+): OpenAI.Chat.ChatCompletionMessageParam[] {
+  return input
+    .map((item: any) => {
+      if (item.role === 'user') {
+        if (Array.isArray(item.content)) {
+          const textParts = item.content
+            .filter(
+              (part: any) => part.type === 'input_text' && part.text?.trim()
+            )
+            .map((part: any) => part.text)
+            .join(' ')
+
+          return {
+            role: 'user',
+            content: textParts || 'Hello',
+          }
+        }
+
+        return {
+          role: 'user',
+          content:
+            typeof item.content === 'string' && item.content.trim()
+              ? item.content
+              : 'Hello',
+        }
+      }
+
+      if (item.role === 'assistant') {
+        const textContent = Array.isArray(item.content)
+          ? item.content
+              .filter(
+                (part: any) => part.type === 'output_text' && part.text?.trim()
+              )
+              .map((part: any) => part.text)
+              .join(' ')
+          : typeof item.content === 'string' && item.content.trim()
+            ? item.content
+            : ''
+
+        const toolCalls = item.tool_calls || null
+        const chatToolCalls = toolCalls
+          ? toolCalls.map((toolCall: any) => ({
+              id: toolCall.call_id || toolCall.id,
+              type: 'function',
+              function: {
+                name: toolCall.name,
+                arguments:
+                  typeof toolCall.arguments === 'string'
+                    ? toolCall.arguments
+                    : JSON.stringify(toolCall.arguments || {}),
+              },
+            }))
+          : undefined
+
+        return {
+          role: 'assistant',
+          content: textContent,
+          tool_calls: chatToolCalls,
+        }
+      }
+
+      if (item.role === 'system') {
+        const content =
+          typeof item.content === 'string'
+            ? item.content
+            : Array.isArray(item.content)
+              ? item.content.map((part: any) => part.text || '').join(' ')
+              : 'You are a helpful assistant.'
+
+        return {
+          role: 'system',
+          content: content.trim() || 'You are a helpful assistant.',
+        }
+      }
+
+      if (item.type === 'function_call_output') {
+        return {
+          role: 'tool',
+          tool_call_id: item.call_id,
+          content:
+            typeof item.output === 'string'
+              ? item.output
+              : JSON.stringify(item.output),
+        }
+      }
+
+      return {
+        ...item,
+        content:
+          typeof item.content === 'string' && item.content.trim()
+            ? item.content
+            : 'Message received.',
+      }
+    })
+    .filter((message: any) => {
+      if (message.role === 'assistant' && message.tool_calls?.length) {
+        return true
+      }
+      return typeof message.content === 'string' && message.content.trim()
+    })
+}
+
+function addCustomInstructions(
+  messages: OpenAI.Chat.ChatCompletionMessageParam[],
+  customInstructions?: string
+): void {
+  if (!customInstructions) {
+    return
+  }
+
+  const systemIndex = messages.findIndex(message => message.role === 'system')
+  if (systemIndex === -1) {
+    messages.unshift({
+      role: 'system',
+      content: customInstructions,
+    })
+    return
+  }
+
+  const existing = String(messages[systemIndex]?.content || '').trim()
+  if (!existing.includes(customInstructions.trim())) {
+    ;(messages[systemIndex] as any).content = existing
+      ? `${customInstructions}\n\n${existing}`
+      : customInstructions
+  }
+}
+
+function convertToolsForChatCompletions(finalToolsForApi: any[]) {
+  if (finalToolsForApi.length === 0) {
+    return undefined
+  }
+
+  return finalToolsForApi.map(tool => {
+    if (tool.type === 'function') {
+      return {
+        type: 'function',
+        function: {
+          name: tool.name,
+          description: tool.description,
+          parameters: tool.parameters,
+        },
+      }
+    }
+    return tool
+  })
+}
+
+export async function listOpenAICompatibleModels(
+  getClient: OpenAIClientGetter
+): Promise<OpenAI.Models.Model[]> {
+  const modelsPage = await getClient().models.list()
+  return modelsPage.data.sort((a, b) => a.id.localeCompare(b.id))
+}
+
+export async function createOpenAICompatibleResponse(
+  provider: OpenAICompatibleProviderKey,
+  getClient: OpenAIClientGetter,
+  input: OpenAI.Responses.Request.InputItemLike[],
+  stream: boolean = false,
+  customInstructions?: string,
+  signal?: AbortSignal
+): Promise<any> {
+  const client = getClient()
+  const settings = useSettingsStore().config
+  const finalToolsForApi = await buildToolsForProvider()
+  const messages = convertResponsesInputToChatMessages(input)
+
+  addCustomInstructions(messages, customInstructions)
+
+  console.log(
+    `[${provider}] Final messages:`,
+    JSON.stringify(messages, null, 2)
+  )
+
+  const model =
+    settings.assistantModel || PROVIDER_CONFIGS[provider].defaultModel
+  const params: OpenAI.Chat.ChatCompletionCreateParams = {
+    model,
+    messages,
+    ...(!model.startsWith('gpt-5')
+      ? {
+          temperature: settings.assistantTemperature,
+          top_p: settings.assistantTopP,
+        }
+      : {}),
+    tools: convertToolsForChatCompletions(finalToolsForApi),
+    stream,
+  }
+
+  if (stream) {
+    const chatStream = await client.chat.completions.create(params as any, {
+      signal,
+    })
+    return convertLocalLLMStreamToResponsesFormat(chatStream, provider)
+  }
+
+  return client.chat.completions.create(params as any, { signal })
+}

--- a/src/services/llmProviders/providerCatalog.ts
+++ b/src/services/llmProviders/providerCatalog.ts
@@ -1,0 +1,71 @@
+export type AIProviderKey =
+  | 'openai'
+  | 'openrouter'
+  | 'ollama'
+  | 'lm-studio'
+  | 'zai'
+  | 'minimax'
+
+export type ChatCompletionsProviderKey = Exclude<AIProviderKey, 'openai'>
+
+export interface ProviderConfig {
+  displayName: string
+  defaultModel: string
+  nativeWebSearch: boolean
+}
+
+export const PROVIDER_CONFIGS: Record<AIProviderKey, ProviderConfig> = {
+  openai: {
+    displayName: 'OpenAI',
+    defaultModel: 'gpt-4.1-mini',
+    nativeWebSearch: true,
+  },
+  openrouter: {
+    displayName: 'OpenRouter',
+    defaultModel: 'gpt-4.1-mini',
+    nativeWebSearch: true,
+  },
+  ollama: {
+    displayName: 'Ollama',
+    defaultModel: 'llama3.2',
+    nativeWebSearch: false,
+  },
+  'lm-studio': {
+    displayName: 'LM Studio',
+    defaultModel: 'llama3.2',
+    nativeWebSearch: false,
+  },
+  zai: {
+    displayName: 'Z.ai',
+    defaultModel: 'glm-5.1',
+    nativeWebSearch: false,
+  },
+  minimax: {
+    displayName: 'MiniMax',
+    defaultModel: 'MiniMax-M2.7',
+    nativeWebSearch: false,
+  },
+}
+
+export const ZAI_CODING_BASE_URL = 'https://api.z.ai/api/coding/paas/v4'
+export const MINIMAX_OPENAI_BASE_URL = 'https://api.minimax.io/v1'
+
+export const CHAT_COMPLETIONS_PROVIDERS: ChatCompletionsProviderKey[] = [
+  'openrouter',
+  'ollama',
+  'lm-studio',
+  'zai',
+  'minimax',
+]
+
+export function getProviderDisplayName(provider: string): string {
+  return PROVIDER_CONFIGS[provider as AIProviderKey]?.displayName || provider
+}
+
+export function isChatCompletionsProvider(
+  provider: string
+): provider is ChatCompletionsProviderKey {
+  return CHAT_COMPLETIONS_PROVIDERS.includes(
+    provider as ChatCompletionsProviderKey
+  )
+}

--- a/src/services/llmProviders/streamAdapters.ts
+++ b/src/services/llmProviders/streamAdapters.ts
@@ -1,6 +1,6 @@
 export async function* convertLocalLLMStreamToResponsesFormat(
   stream: any,
-  provider: 'ollama' | 'lm-studio'
+  provider: 'ollama' | 'lm-studio' | 'zai' | 'minimax'
 ) {
   let responseId = `${provider}-${Date.now()}`
   let messageItemId = `message-${Date.now()}`

--- a/src/services/llmProviders/tools.ts
+++ b/src/services/llmProviders/tools.ts
@@ -4,6 +4,7 @@ import {
   PREDEFINED_OPENAI_TOOLS,
   type ApiRequestBodyFunctionTool,
 } from '../../utils/assistantTools'
+import { PROVIDER_CONFIGS } from './providerCatalog'
 
 export async function buildToolsForProvider(): Promise<any[]> {
   const settings = useSettingsStore().config
@@ -106,10 +107,7 @@ export async function buildToolsForProvider(): Promise<any[]> {
       })
     finalToolsForApi.length = 0
     finalToolsForApi.push(...allowedTools)
-  } else if (
-    settings.aiProvider === 'ollama' ||
-    settings.aiProvider === 'lm-studio'
-  ) {
+  } else if (!PROVIDER_CONFIGS[settings.aiProvider].nativeWebSearch) {
     const allowedTools = finalToolsForApi.filter(tool => {
       if (
         tool.type === 'image_generation' ||

--- a/src/services/llmProviders/zai.ts
+++ b/src/services/llmProviders/zai.ts
@@ -1,0 +1,27 @@
+import type OpenAI from 'openai'
+import { getZAIClient } from '../apiClients'
+import {
+  createOpenAICompatibleResponse,
+  listOpenAICompatibleModels,
+} from './openAICompatible'
+
+export const listZAIModels = async (): Promise<OpenAI.Models.Model[]> => {
+  return listOpenAICompatibleModels(getZAIClient)
+}
+
+export const createZAIResponse = async (
+  input: OpenAI.Responses.Request.InputItemLike[],
+  _previousResponseId: string | null,
+  stream: boolean = false,
+  customInstructions?: string,
+  signal?: AbortSignal
+): Promise<any> => {
+  return createOpenAICompatibleResponse(
+    'zai',
+    getZAIClient,
+    input,
+    stream,
+    customInstructions,
+    signal
+  )
+}

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -4,6 +4,13 @@ import { useConversationStore } from './conversationStore'
 import { useGeneralStore } from './generalStore'
 import { reinitializeClients } from '../services/apiClients'
 import { DEFAULT_PERSONA_PROMPT } from '../prompts/defaultPersonaPrompt'
+import {
+  MINIMAX_OPENAI_BASE_URL,
+  PROVIDER_CONFIGS,
+  ZAI_CODING_BASE_URL,
+  getProviderDisplayName,
+  type AIProviderKey,
+} from '../services/llmProviders/providerCatalog'
 
 export const DEFAULT_ASSISTANT_PERSONA_PROMPT = DEFAULT_PERSONA_PROMPT
 
@@ -22,10 +29,12 @@ Do not add any conversational fluff, commentary, or an introductory/concluding s
 export interface AliceSettings {
   VITE_OPENAI_API_KEY: string
   VITE_OPENROUTER_API_KEY: string
+  VITE_ZAI_API_KEY: string
+  VITE_MINIMAX_API_KEY: string
   VITE_GROQ_API_KEY: string
   VITE_GOOGLE_API_KEY: string
   sttProvider: 'openai' | 'groq' | 'google' | 'local'
-  aiProvider: 'openai' | 'openrouter' | 'ollama' | 'lm-studio'
+  aiProvider: AIProviderKey
 
   // Local Go Backend STT settings
   localSttModel: string
@@ -35,6 +44,8 @@ export interface AliceSettings {
 
   ollamaBaseUrl: string
   lmStudioBaseUrl: string
+  zaiBaseUrl: string
+  minimaxBaseUrl: string
 
   assistantModel: string
   assistantSystemPrompt: string
@@ -83,16 +94,20 @@ export interface AliceSettings {
 function hasMinimumConfigForOnboarding(config: AliceSettings): boolean {
   return Boolean(
     config.assistantModel?.trim() ||
-      config.VITE_OPENAI_API_KEY?.trim() ||
-      config.VITE_OPENROUTER_API_KEY?.trim() ||
-      config.ollamaBaseUrl?.trim() ||
-      config.lmStudioBaseUrl?.trim()
+    config.VITE_OPENAI_API_KEY?.trim() ||
+    config.VITE_OPENROUTER_API_KEY?.trim() ||
+    config.VITE_ZAI_API_KEY?.trim() ||
+    config.VITE_MINIMAX_API_KEY?.trim() ||
+    config.ollamaBaseUrl?.trim() ||
+    config.lmStudioBaseUrl?.trim()
   )
 }
 
 const defaultSettings: AliceSettings = {
   VITE_OPENAI_API_KEY: '',
   VITE_OPENROUTER_API_KEY: '',
+  VITE_ZAI_API_KEY: '',
+  VITE_MINIMAX_API_KEY: '',
   VITE_GROQ_API_KEY: '',
   VITE_GOOGLE_API_KEY: '',
   sttProvider: 'openai',
@@ -105,6 +120,8 @@ const defaultSettings: AliceSettings = {
 
   ollamaBaseUrl: 'http://localhost:11434',
   lmStudioBaseUrl: 'http://localhost:1234',
+  zaiBaseUrl: ZAI_CODING_BASE_URL,
+  minimaxBaseUrl: MINIMAX_OPENAI_BASE_URL,
 
   assistantModel: 'gpt-4.1-mini',
   assistantSystemPrompt: DEFAULT_PERSONA_PROMPT,
@@ -159,6 +176,8 @@ const defaultSettings: AliceSettings = {
 const settingKeyToLabelMap: Record<keyof AliceSettings, string> = {
   VITE_OPENAI_API_KEY: 'OpenAI API Key',
   VITE_OPENROUTER_API_KEY: 'OpenRouter API Key',
+  VITE_ZAI_API_KEY: 'Z.ai API Key',
+  VITE_MINIMAX_API_KEY: 'MiniMax API Key',
   VITE_GROQ_API_KEY: 'Groq API Key (STT)',
   VITE_GOOGLE_API_KEY: 'Google API Key',
   sttProvider: 'Speech-to-Text Provider',
@@ -172,6 +191,8 @@ const settingKeyToLabelMap: Record<keyof AliceSettings, string> = {
 
   ollamaBaseUrl: 'Ollama Base URL',
   lmStudioBaseUrl: 'LM Studio Base URL',
+  zaiBaseUrl: 'Z.ai Base URL',
+  minimaxBaseUrl: 'MiniMax Base URL',
 
   assistantModel: 'Assistant Model',
   assistantSystemPrompt: 'Assistant Persona Prompt',
@@ -218,6 +239,8 @@ const settingKeyToLabelMap: Record<keyof AliceSettings, string> = {
 const ESSENTIAL_CORE_API_KEYS: (keyof AliceSettings)[] = [
   'VITE_OPENAI_API_KEY',
   'VITE_OPENROUTER_API_KEY',
+  'VITE_ZAI_API_KEY',
+  'VITE_MINIMAX_API_KEY',
 ]
 
 function requiresOpenAIKey(config: AliceSettings): boolean {
@@ -289,6 +312,8 @@ export const useSettingsStore = defineStore('settings', () => {
       'openrouter',
       'ollama',
       'lm-studio',
+      'zai',
+      'minimax',
     ] as const
     if (!validAIProviders.includes(validated.aiProvider as any)) {
       validated.aiProvider = 'openai'
@@ -351,6 +376,10 @@ export const useSettingsStore = defineStore('settings', () => {
       essentialKeys.push('VITE_OPENAI_API_KEY')
     } else if (settings.value.aiProvider === 'openrouter') {
       essentialKeys.push('VITE_OPENROUTER_API_KEY')
+    } else if (settings.value.aiProvider === 'zai') {
+      essentialKeys.push('VITE_ZAI_API_KEY', 'zaiBaseUrl')
+    } else if (settings.value.aiProvider === 'minimax') {
+      essentialKeys.push('VITE_MINIMAX_API_KEY', 'minimaxBaseUrl')
     } else if (settings.value.aiProvider === 'ollama') {
       essentialKeys.push('ollamaBaseUrl')
     } else if (settings.value.aiProvider === 'lm-studio') {
@@ -398,6 +427,20 @@ export const useSettingsStore = defineStore('settings', () => {
       return !!settings.value.VITE_OPENROUTER_API_KEY?.trim()
     }
 
+    if (settings.value.aiProvider === 'zai') {
+      return (
+        !!settings.value.VITE_ZAI_API_KEY?.trim() &&
+        !!settings.value.zaiBaseUrl?.trim()
+      )
+    }
+
+    if (settings.value.aiProvider === 'minimax') {
+      return (
+        !!settings.value.VITE_MINIMAX_API_KEY?.trim() &&
+        !!settings.value.minimaxBaseUrl?.trim()
+      )
+    }
+
     if (settings.value.aiProvider === 'ollama') {
       return !!settings.value.ollamaBaseUrl?.trim()
     }
@@ -409,55 +452,55 @@ export const useSettingsStore = defineStore('settings', () => {
     return true
   })
 
-    const config = computed<Readonly<AliceSettings>>(() => {
-      if (isProduction.value) {
-        return settings.value
-      }
+  const config = computed<Readonly<AliceSettings>>(() => {
+    if (isProduction.value) {
+      return settings.value
+    }
 
-      const envOverrides = Object.fromEntries(
-        Object.entries(import.meta.env)
-          .filter(
-            ([key]) =>
-              key.startsWith('VITE_') ||
-              key.startsWith('assistant') ||
-              key === 'MAX_HISTORY_MESSAGES_FOR_API' ||
-              key === 'SUMMARIZATION_MESSAGE_COUNT' ||
-              key === 'SUMMARIZATION_MODEL' ||
-              key === 'SUMMARIZATION_SYSTEM_PROMPT' ||
-              key === 'sttProvider' ||
-              key === 'aiProvider' ||
-              key === 'onboardingCompleted'
-          )
-          .map(([key, value]) => {
-            if (
-              key === 'MAX_HISTORY_MESSAGES_FOR_API' ||
-              key === 'SUMMARIZATION_MESSAGE_COUNT' ||
-              key === 'assistantTemperature' ||
-              key === 'assistantTopP' ||
-              key === 'ragTopK' ||
-              key === 'ragMaxContextChars'
-            ) {
-              return [key, parseFloat(String(value))]
-            }
-            if (key === 'assistantTools' && typeof value === 'string') {
-              return [
-                key,
-                value
-                  .split(',')
-                  .map(t => t.trim())
-                  .filter(Boolean),
-              ]
-            }
-            return [key, String(value)]
-          })
-      )
+    const envOverrides = Object.fromEntries(
+      Object.entries(import.meta.env)
+        .filter(
+          ([key]) =>
+            key.startsWith('VITE_') ||
+            key.startsWith('assistant') ||
+            key === 'MAX_HISTORY_MESSAGES_FOR_API' ||
+            key === 'SUMMARIZATION_MESSAGE_COUNT' ||
+            key === 'SUMMARIZATION_MODEL' ||
+            key === 'SUMMARIZATION_SYSTEM_PROMPT' ||
+            key === 'sttProvider' ||
+            key === 'aiProvider' ||
+            key === 'onboardingCompleted'
+        )
+        .map(([key, value]) => {
+          if (
+            key === 'MAX_HISTORY_MESSAGES_FOR_API' ||
+            key === 'SUMMARIZATION_MESSAGE_COUNT' ||
+            key === 'assistantTemperature' ||
+            key === 'assistantTopP' ||
+            key === 'ragTopK' ||
+            key === 'ragMaxContextChars'
+          ) {
+            return [key, parseFloat(String(value))]
+          }
+          if (key === 'assistantTools' && typeof value === 'string') {
+            return [
+              key,
+              value
+                .split(',')
+                .map(t => t.trim())
+                .filter(Boolean),
+            ]
+          }
+          return [key, String(value)]
+        })
+    )
 
-      return {
-        ...defaultSettings,
-        ...envOverrides,
-        ...settings.value,
-      }
-    })
+    return {
+      ...defaultSettings,
+      ...envOverrides,
+      ...settings.value,
+    }
+  })
 
   async function loadSettings() {
     if (initialLoadAttempted.value) {
@@ -635,11 +678,15 @@ export const useSettingsStore = defineStore('settings', () => {
       settings.value[key] = value as 'openai' | 'groq' | 'google' | 'local'
     }
     if (key === 'aiProvider') {
-      settings.value[key] = value as
-        | 'openai'
-        | 'openrouter'
-        | 'ollama'
-        | 'lm-studio'
+      settings.value[key] = value as AIProviderKey
+      if (settings.value.aiProvider === 'zai') {
+        settings.value.assistantModel = PROVIDER_CONFIGS.zai.defaultModel
+        settings.value.SUMMARIZATION_MODEL = PROVIDER_CONFIGS.zai.defaultModel
+      } else if (settings.value.aiProvider === 'minimax') {
+        settings.value.assistantModel = PROVIDER_CONFIGS.minimax.defaultModel
+        settings.value.SUMMARIZATION_MODEL =
+          PROVIDER_CONFIGS.minimax.defaultModel
+      }
     }
     if (key === 'assistantReasoningEffort') {
       settings.value[key] = value as 'minimal' | 'low' | 'medium' | 'high'
@@ -677,8 +724,12 @@ export const useSettingsStore = defineStore('settings', () => {
     if (
       key === 'VITE_OPENAI_API_KEY' ||
       key === 'VITE_OPENROUTER_API_KEY' ||
+      key === 'VITE_ZAI_API_KEY' ||
+      key === 'VITE_MINIMAX_API_KEY' ||
       key === 'ollamaBaseUrl' ||
       key === 'lmStudioBaseUrl' ||
+      key === 'zaiBaseUrl' ||
+      key === 'minimaxBaseUrl' ||
       key === 'aiProvider'
     ) {
       coreOpenAISettingsValid.value = false
@@ -715,6 +766,8 @@ export const useSettingsStore = defineStore('settings', () => {
       const plainSettings: AliceSettings = {
         VITE_OPENAI_API_KEY: settings.value.VITE_OPENAI_API_KEY,
         VITE_OPENROUTER_API_KEY: settings.value.VITE_OPENROUTER_API_KEY,
+        VITE_ZAI_API_KEY: settings.value.VITE_ZAI_API_KEY,
+        VITE_MINIMAX_API_KEY: settings.value.VITE_MINIMAX_API_KEY,
         VITE_GROQ_API_KEY: settings.value.VITE_GROQ_API_KEY,
         VITE_GOOGLE_API_KEY: settings.value.VITE_GOOGLE_API_KEY,
         sttProvider: settings.value.sttProvider,
@@ -727,6 +780,8 @@ export const useSettingsStore = defineStore('settings', () => {
 
         ollamaBaseUrl: settings.value.ollamaBaseUrl,
         lmStudioBaseUrl: settings.value.lmStudioBaseUrl,
+        zaiBaseUrl: settings.value.zaiBaseUrl,
+        minimaxBaseUrl: settings.value.minimaxBaseUrl,
         assistantModel: settings.value.assistantModel,
         assistantSystemPrompt: settings.value.assistantSystemPrompt,
         assistantTemperature: settings.value.assistantTemperature,
@@ -817,6 +872,32 @@ export const useSettingsStore = defineStore('settings', () => {
         isSaving.value = false
         return
       }
+    } else if (currentConfigForTest.aiProvider === 'zai') {
+      if (!currentConfigForTest.VITE_ZAI_API_KEY?.trim()) {
+        error.value = `Essential setting '${settingKeyToLabelMap.VITE_ZAI_API_KEY}' is missing.`
+        generalStore.statusMessage = 'Z.ai API Key is required.'
+        isSaving.value = false
+        return
+      }
+      if (!currentConfigForTest.zaiBaseUrl?.trim()) {
+        error.value = `Essential setting '${settingKeyToLabelMap.zaiBaseUrl}' is missing.`
+        generalStore.statusMessage = 'Z.ai Base URL is required.'
+        isSaving.value = false
+        return
+      }
+    } else if (currentConfigForTest.aiProvider === 'minimax') {
+      if (!currentConfigForTest.VITE_MINIMAX_API_KEY?.trim()) {
+        error.value = `Essential setting '${settingKeyToLabelMap.VITE_MINIMAX_API_KEY}' is missing.`
+        generalStore.statusMessage = 'MiniMax API Key is required.'
+        isSaving.value = false
+        return
+      }
+      if (!currentConfigForTest.minimaxBaseUrl?.trim()) {
+        error.value = `Essential setting '${settingKeyToLabelMap.minimaxBaseUrl}' is missing.`
+        generalStore.statusMessage = 'MiniMax Base URL is required.'
+        isSaving.value = false
+        return
+      }
     } else if (currentConfigForTest.aiProvider === 'ollama') {
       if (!currentConfigForTest.ollamaBaseUrl?.trim()) {
         error.value = `Essential setting '${settingKeyToLabelMap.ollamaBaseUrl}' is missing.`
@@ -869,15 +950,9 @@ export const useSettingsStore = defineStore('settings', () => {
       openAIServiceTestSuccess = true
       coreOpenAISettingsValid.value = true
     } catch (e: any) {
-      const providerNameMap = {
-        openai: 'OpenAI',
-        openrouter: 'OpenRouter',
-        ollama: 'Ollama',
-        'lm-studio': 'LM Studio',
-      }
-      const providerName =
-        providerNameMap[currentConfigForTest.aiProvider] ||
+      const providerName = getProviderDisplayName(
         currentConfigForTest.aiProvider
+      )
       error.value = `${providerName} API connection test failed: ${e.message}. Check your ${providerName} configuration.`
       coreOpenAISettingsValid.value = false
       openAIServiceTestSuccess = false
@@ -885,15 +960,9 @@ export const useSettingsStore = defineStore('settings', () => {
 
     if (openAIServiceTestSuccess) {
       if (!currentConfigForTest.assistantModel?.trim()) {
-        const providerNameMap = {
-          openai: 'OpenAI',
-          openrouter: 'OpenRouter',
-          ollama: 'Ollama',
-          'lm-studio': 'LM Studio',
-        }
-        const providerName =
-          providerNameMap[currentConfigForTest.aiProvider] ||
+        const providerName = getProviderDisplayName(
           currentConfigForTest.aiProvider
+        )
         error.value = `${providerName} connection is valid. Please select an '${settingKeyToLabelMap.assistantModel}'.`
         generalStore.statusMessage = 'Assistant model not selected.'
         successMessage.value = `${providerName} connection is valid. Models loaded. Please complete model selections.`
@@ -901,15 +970,9 @@ export const useSettingsStore = defineStore('settings', () => {
         return
       }
       if (!currentConfigForTest.SUMMARIZATION_MODEL?.trim()) {
-        const providerNameMap = {
-          openai: 'OpenAI',
-          openrouter: 'OpenRouter',
-          ollama: 'Ollama',
-          'lm-studio': 'LM Studio',
-        }
-        const providerName =
-          providerNameMap[currentConfigForTest.aiProvider] ||
+        const providerName = getProviderDisplayName(
           currentConfigForTest.aiProvider
+        )
         error.value = `${providerName} connection is valid. Please select a '${settingKeyToLabelMap.SUMMARIZATION_MODEL}'.`
         generalStore.statusMessage = 'Summarization model not selected.'
         successMessage.value = `${providerName} connection is valid. Models loaded. Please complete model selections.`
@@ -951,22 +1014,29 @@ export const useSettingsStore = defineStore('settings', () => {
   async function completeOnboarding(onboardingData: {
     VITE_OPENAI_API_KEY: string
     VITE_OPENROUTER_API_KEY: string
+    VITE_ZAI_API_KEY?: string
+    VITE_MINIMAX_API_KEY?: string
     sttProvider: 'openai' | 'groq' | 'google' | 'local'
     ttsProvider?: 'openai' | 'google' | 'local'
     embeddingProvider?: 'openai' | 'local'
-    aiProvider: 'openai' | 'openrouter' | 'ollama' | 'lm-studio'
+    aiProvider: AIProviderKey
     assistantModel?: string
     summarizationModel?: string
     VITE_GROQ_API_KEY: string
     VITE_GOOGLE_API_KEY: string
     ollamaBaseUrl?: string
     lmStudioBaseUrl?: string
+    zaiBaseUrl?: string
+    minimaxBaseUrl?: string
     useLocalModels?: boolean
     localSttLanguage?: string
   }) {
     settings.value.VITE_OPENAI_API_KEY = onboardingData.VITE_OPENAI_API_KEY
     settings.value.VITE_OPENROUTER_API_KEY =
       onboardingData.VITE_OPENROUTER_API_KEY
+    settings.value.VITE_ZAI_API_KEY = onboardingData.VITE_ZAI_API_KEY || ''
+    settings.value.VITE_MINIMAX_API_KEY =
+      onboardingData.VITE_MINIMAX_API_KEY || ''
     settings.value.sttProvider = onboardingData.sttProvider
     settings.value.aiProvider = onboardingData.aiProvider
     settings.value.VITE_GROQ_API_KEY = onboardingData.VITE_GROQ_API_KEY
@@ -1000,6 +1070,12 @@ export const useSettingsStore = defineStore('settings', () => {
     }
     if (onboardingData.lmStudioBaseUrl) {
       settings.value.lmStudioBaseUrl = onboardingData.lmStudioBaseUrl
+    }
+    if (onboardingData.zaiBaseUrl) {
+      settings.value.zaiBaseUrl = onboardingData.zaiBaseUrl
+    }
+    if (onboardingData.minimaxBaseUrl) {
+      settings.value.minimaxBaseUrl = onboardingData.minimaxBaseUrl
     }
 
     settings.value.onboardingCompleted = true


### PR DESCRIPTION
## Summary
- Added Z.ai and MiniMax as selectable OpenAI-compatible chat providers.
- Wired provider-specific API keys, base URLs, model loading, onboarding, and settings UI.
- Kept native web search disabled for these providers while preserving Alice tool-based web search.