### PR TITLE
Use GPT Image 2 for OpenAI image generation

### DIFF
--- a/src/services/llmProviders/__tests__/tools.test.ts
+++ b/src/services/llmProviders/__tests__/tools.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { useSettingsStore } from '../../../stores/settingsStore'
+
+function installWindowMocks() {
+  ;(globalThis as any).window = {
+    customToolsAPI: {
+      list: vi.fn().mockResolvedValue({
+        success: true,
+        data: {
+          tools: [],
+          diagnostics: [],
+          filePath: '',
+          lastModified: Date.now(),
+        },
+      }),
+    },
+  }
+}
+
+describe('buildToolsForProvider', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    installWindowMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete (globalThis as any).window
+  })
+
+  it('uses GPT Image 2 for OpenAI image generation', async () => {
+    const settingsStore = useSettingsStore()
+    settingsStore.updateSetting('aiProvider', 'openai')
+    settingsStore.updateSetting('assistantModel', 'gpt-5')
+    settingsStore.updateSetting('assistantReasoningEffort', 'medium')
+
+    const { buildToolsForProvider } = await import('../tools')
+    const tools = await buildToolsForProvider()
+
+    expect(tools).toContainEqual({
+      type: 'image_generation',
+      model: 'gpt-image-2',
+      partial_images: 2,
+    })
+  })
+})

--- a/src/services/llmProviders/tools.ts
+++ b/src/services/llmProviders/tools.ts
@@ -6,6 +6,8 @@ import {
 } from '../../utils/assistantTools'
 import { PROVIDER_CONFIGS } from './providerCatalog'
 
+const OPENAI_IMAGE_GENERATION_MODEL = 'gpt-image-2'
+
 export async function buildToolsForProvider(): Promise<any[]> {
   const settings = useSettingsStore().config
   const finalToolsForApi: any[] = []
@@ -71,12 +73,20 @@ export async function buildToolsForProvider(): Promise<any[]> {
 
     if (!isOModel) {
       if (!isGpt5WithMinimalReasoning) {
-        finalToolsForApi.push({ type: 'image_generation', partial_images: 2 })
+        finalToolsForApi.push({
+          type: 'image_generation',
+          model: OPENAI_IMAGE_GENERATION_MODEL,
+          partial_images: 2,
+        })
         finalToolsForApi.push({ type: 'web_search_preview' })
       }
     } else {
       if (modelName.includes('o3-pro') && modelName === 'o3') {
-        finalToolsForApi.push({ type: 'image_generation', partial_images: 2 })
+        finalToolsForApi.push({
+          type: 'image_generation',
+          model: OPENAI_IMAGE_GENERATION_MODEL,
+          partial_images: 2,
+        })
         finalToolsForApi.push({ type: 'web_search_preview' })
       }
     }


### PR DESCRIPTION
## Summary
- Updated the OpenAI hosted image generation tool to request GPT Image 2.
- Kept the existing partial image streaming behavior unchanged.
- Added coverage for the OpenAI image generation tool payload.