### PR TITLE
Fix settings window initial view

### DIFF
--- a/electron/main/windowManager.ts
+++ b/electron/main/windowManager.ts
@@ -218,6 +218,7 @@ export async function createSettingsWindow(): Promise<BrowserWindow> {
     parent: win || undefined,
     modal: false,
     backgroundColor: '#1f2937',
+    show: false,
     webPreferences: {
       preload: getPreloadPath(),
       offscreen: false,
@@ -231,6 +232,9 @@ export async function createSettingsWindow(): Promise<BrowserWindow> {
   } else {
     await settingsWindow.loadFile(getIndexHtmlPath(), { hash: arg })
   }
+
+  settingsWindow.show()
+  settingsWindow.focus()
 
   settingsWindow.on('closed', () => {
     settingsWindow = null

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,13 +12,23 @@ const app = createApp(App)
 app.use(createPinia())
 app.use(router)
 
+async function mountApp(): Promise<void> {
+  try {
+    await router.isReady()
+  } catch (error) {
+    console.error('Router failed to finish initial navigation:', error)
+  }
+  app.mount('#app')
+}
+
 // Initialize clients and then mount the app
 initializeClients()
   .then(() => {
     console.log('All clients initialized, mounting app')
-    app.mount('#app')
   })
   .catch(error => {
     console.error('Failed to initialize clients, mounting app anyway:', error)
-    app.mount('#app')
+  })
+  .finally(() => {
+    mountApp()
   })


### PR DESCRIPTION
## Summary
- Wait for the renderer router to resolve the initial hash before mounting.
- Create the settings window hidden and show it only after the settings route has loaded.
- Prevent the main app view from flashing before the settings UI appears.