### PR TITLE
Fix Z.ai and MiniMax provider inference

### DIFF
--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -216,6 +216,10 @@ import { PREDEFINED_OPENAI_TOOLS } from '../utils/assistantTools'
 import { DEFAULT_ASSISTANT_PERSONA_PROMPT } from '../stores/settingsStore'
 import { useHotkeyRecording } from '../composables/useHotkeyRecording'
 import { useGoogleAuth } from '../composables/useGoogleAuth'
+import {
+  getStaticModelsForProvider,
+  type ProviderModelDefinition,
+} from '../services/llmProviders/providerCatalog'
 import CoreSettingsTab from './settings/CoreSettingsTab.vue'
 import AssistantSettingsTab from './settings/AssistantSettingsTab.vue'
 import HotkeysTab from './settings/HotkeysTab.vue'
@@ -272,6 +276,18 @@ const isBrowserContextToolActive = computed(() => {
 })
 
 const availableModelsForSelect = computed(() => {
+  const staticModels = getStaticModelsForProvider(
+    currentSettings.value.aiProvider
+  )
+  if (staticModels.length > 0) {
+    const staticModelIds = new Set(staticModels.map(model => model.id))
+    return [
+      ...staticModels.map((model: ProviderModelDefinition) => ({
+        id: model.id,
+      })),
+      ...availableModels.value.filter(model => !staticModelIds.has(model.id)),
+    ]
+  }
   return availableModels.value
 })
 

--- a/src/components/wizard/OnboardingWizard.vue
+++ b/src/components/wizard/OnboardingWizard.vue
@@ -61,9 +61,11 @@ import FinalSetupStep from './steps/FinalSetupStep.vue'
 import OpenAI from 'openai'
 import {
   MINIMAX_OPENAI_BASE_URL,
+  ZAI_CODING_MODELS,
   ZAI_CODING_BASE_URL,
   type AIProviderKey,
 } from '../../services/llmProviders/providerCatalog'
+import { listMiniMaxModelsForConfig } from '../../services/llmProviders/minimax'
 
 const step = ref(1)
 const settingsStore = useSettingsStore()
@@ -90,6 +92,10 @@ const formData = reactive({
   availableModels: [] as string[],
   localSttLanguage: 'auto',
 })
+
+function isAuthError(error: any): boolean {
+  return error?.status === 401 || error?.status === 403
+}
 
 const isTesting = reactive({
   openai: false,
@@ -215,13 +221,25 @@ const fetchAvailableModels = async () => {
       return
     }
 
+    if (formData.aiProvider === 'minimax') {
+      const models = await listMiniMaxModelsForConfig(
+        formData.VITE_MINIMAX_API_KEY,
+        baseURL
+      )
+      formData.availableModels = models.map(model => model.id)
+
+      if (formData.availableModels.length > 0) {
+        formData.assistantModel = formData.availableModels[0]
+        formData.summarizationModel = formData.availableModels[0]
+      }
+      return
+    }
+
     const tempClient = new OpenAI({
       apiKey:
         formData.aiProvider === 'zai'
           ? formData.VITE_ZAI_API_KEY
-          : formData.aiProvider === 'minimax'
-            ? formData.VITE_MINIMAX_API_KEY
-            : formData.aiProvider,
+          : formData.aiProvider,
       baseURL,
       dangerouslyAllowBrowser: true,
     })
@@ -234,8 +252,15 @@ const fetchAvailableModels = async () => {
       formData.summarizationModel = formData.availableModels[0]
     }
   } catch (error) {
+    if (formData.aiProvider === 'zai' && !isAuthError(error)) {
+      formData.availableModels = ZAI_CODING_MODELS.map(model => model.id)
+      formData.assistantModel = formData.availableModels[0] || 'glm-5.1'
+      formData.summarizationModel = formData.availableModels[0] || 'glm-5.1'
+      return
+    }
     console.error('Failed to fetch models:', error)
     formData.availableModels = []
+    throw error
   }
 }
 
@@ -320,17 +345,8 @@ const testZAIKey = async () => {
   testResult.zai.success = false
 
   try {
-    const tempClient = new OpenAI({
-      apiKey: formData.VITE_ZAI_API_KEY,
-      baseURL: formData.zaiBaseUrl,
-      dangerouslyAllowBrowser: true,
-      timeout: 10 * 1000,
-      maxRetries: 1,
-    })
-
-    await tempClient.models.list()
-    testResult.zai.success = true
     await fetchAvailableModels()
+    testResult.zai.success = true
   } catch (e: any) {
     testResult.zai.error =
       'API key or Coding Plan endpoint is invalid or has no permissions.'
@@ -361,17 +377,8 @@ const testMiniMaxKey = async () => {
   testResult.minimax.success = false
 
   try {
-    const tempClient = new OpenAI({
-      apiKey: formData.VITE_MINIMAX_API_KEY,
-      baseURL: formData.minimaxBaseUrl,
-      dangerouslyAllowBrowser: true,
-      timeout: 10 * 1000,
-      maxRetries: 1,
-    })
-
-    await tempClient.models.list()
-    testResult.minimax.success = true
     await fetchAvailableModels()
+    testResult.minimax.success = true
   } catch (e: any) {
     testResult.minimax.error =
       'API key or OpenAI-compatible endpoint is invalid or has no permissions.'

--- a/src/modules/conversation/__tests__/turnManager.test.ts
+++ b/src/modules/conversation/__tests__/turnManager.test.ts
@@ -155,6 +155,7 @@ describe('createTurnManager', () => {
 
     ctx.state.setAudioPlayer({ paused: true })
     ctx.state.setAudioQueueLength(0)
+    ctx.state.setAudioState('IDLE')
     vi.advanceTimersByTime(250)
 
     expect(ctx.deps.getAudioState()).toBe('IDLE')
@@ -198,5 +199,28 @@ describe('createTurnManager', () => {
     expect(ctx.triggerSummarization).not.toHaveBeenCalled()
     manager.dispose()
   })
-})
 
+  it('does not force IDLE while audio playback is being prepared', () => {
+    const ctx = buildDependencies()
+    ctx.state.setAudioPlayer({ paused: true })
+    ctx.state.setAudioQueueLength(0)
+    ctx.state.setAudioState('SPEAKING')
+    const manager = createTurnManager(ctx.deps)
+
+    manager.finalizeAfterStream({
+      streamEndedNormally: true,
+      isContinuationAfterTool: false,
+    })
+
+    vi.advanceTimersByTime(250)
+
+    expect(ctx.deps.getAudioState()).toBe('SPEAKING')
+    expect(ctx.triggerSummarization).not.toHaveBeenCalled()
+
+    ctx.state.setAudioState('IDLE')
+    vi.advanceTimersByTime(250)
+
+    expect(ctx.triggerSummarization).toHaveBeenCalled()
+    manager.dispose()
+  })
+})

--- a/src/modules/conversation/turnManager.ts
+++ b/src/modules/conversation/turnManager.ts
@@ -64,6 +64,11 @@ export function createTurnManager(
     if (!streamEndedNormally) return
 
     const finalizeInterval = setInterval(() => {
+      const audioState = dependencies.getAudioState()
+      if (audioState === 'SPEAKING') {
+        return
+      }
+
       const audioPlayer = dependencies.getAudioPlayer()
       if (audioPlayer && !audioPlayer.paused) {
         return
@@ -73,8 +78,7 @@ export function createTurnManager(
         return
       }
 
-      const audioState = dependencies.getAudioState()
-      if (audioState === 'SPEAKING' || audioState === 'WAITING_FOR_RESPONSE') {
+      if (audioState === 'WAITING_FOR_RESPONSE') {
         dependencies.setAudioState(
           dependencies.isRecordingRequested() ? 'LISTENING' : 'IDLE'
         )
@@ -98,4 +102,3 @@ export function createTurnManager(
     dispose,
   }
 }
-

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -28,7 +28,14 @@ import {
   createMiniMaxResponse,
   listMiniMaxModels,
 } from './llmProviders/minimax'
-import { isChatCompletionsProvider } from './llmProviders/providerCatalog'
+import {
+  createMiniMaxChatCompletionViaMain,
+  stripReasoningFromMiniMaxContent,
+} from './llmProviders/openAICompatible'
+import {
+  getSafeProviderModel,
+  isChatCompletionsProvider,
+} from './llmProviders/providerCatalog'
 import type { AppChatMessageContentPart } from '../types/chat'
 import type { RagSearchResult } from '../types/rag'
 
@@ -715,16 +722,21 @@ export const createSummarizationResponse = async (
     .join('\n\n')
 
   if (isChatCompletionsProvider(settings.aiProvider)) {
-    const response = await client.chat.completions.create({
-      model: summarizationModel,
+    const params = {
+      model: getSafeProviderModel(settings.aiProvider, summarizationModel),
       messages: [
         { role: 'system', content: systemPrompt },
         { role: 'user', content: combinedText },
       ],
       stream: false,
-    } as any)
+    } as any
+    const response =
+      settings.aiProvider === 'minimax'
+        ? await createMiniMaxChatCompletionViaMain(params)
+        : await client.chat.completions.create(params)
 
-    return response.choices[0]?.message?.content?.trim() || null
+    const content = response.choices[0]?.message?.content?.trim()
+    return content ? stripReasoningFromMiniMaxContent(content) : null
   } else {
     const response = await client.responses.create({
       model: summarizationModel,
@@ -767,18 +779,23 @@ export const createContextAnalysisResponse = async (
     .join('\n\n')
 
   if (isChatCompletionsProvider(settings.aiProvider)) {
-    const response = await client.chat.completions.create({
-      model: analysisModel,
+    const params = {
+      model: getSafeProviderModel(settings.aiProvider, analysisModel),
       messages: [
         { role: 'system', content: analysisSystemPrompt },
         { role: 'user', content: combinedText },
       ],
       stream: false,
-    } as any)
+    } as any
+    const response =
+      settings.aiProvider === 'minimax'
+        ? await createMiniMaxChatCompletionViaMain(params)
+        : await client.chat.completions.create(params)
 
-    return (
-      response.choices[0]?.message?.content?.trim().replace(/"/g, '') || null
-    )
+    const content = response.choices[0]?.message?.content?.trim()
+    return content
+      ? stripReasoningFromMiniMaxContent(content).replace(/"/g, '')
+      : null
   } else {
     const response = await client.responses.create({
       model: analysisModel,

--- a/src/services/llmProviders/__tests__/minimax.test.ts
+++ b/src/services/llmProviders/__tests__/minimax.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { listMiniMaxModelsForConfig } from '../minimax'
+
+describe('MiniMax model listing', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete (globalThis as any).window
+  })
+
+  it('uses the Electron HTTP bridge without OpenAI SDK stainless headers', async () => {
+    const request = vi.fn().mockResolvedValue({
+      success: true,
+      status: 200,
+      data: {
+        data: [{ id: 'MiniMax-M2.7' }, { id: 'unrelated-model' }],
+      },
+    })
+    ;(globalThis as any).window = {
+      httpAPI: {
+        request,
+      },
+    }
+
+    const models = await listMiniMaxModelsForConfig(
+      'sk-test',
+      'https://api.minimax.io/v1/'
+    )
+
+    expect(models.map(model => model.id)).toEqual(['MiniMax-M2.7'])
+    expect(request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'https://api.minimax.io/v1/models',
+        method: 'GET',
+        headers: {
+          Authorization: 'Bearer sk-test',
+        },
+      })
+    )
+    expect(request.mock.calls[0][0].headers['x-stainless-os']).toBeUndefined()
+  })
+})

--- a/src/services/llmProviders/__tests__/openAICompatible.test.ts
+++ b/src/services/llmProviders/__tests__/openAICompatible.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { useSettingsStore } from '../../../stores/settingsStore'
+import {
+  createOpenAICompatibleResponse,
+  stripReasoningFromMiniMaxContent,
+} from '../openAICompatible'
+
+function installWindowMocks() {
+  ;(globalThis as any).window = {
+    customToolsAPI: {
+      list: vi.fn().mockResolvedValue({
+        success: true,
+        data: {
+          tools: [],
+          diagnostics: [],
+          filePath: '',
+          lastModified: Date.now(),
+        },
+      }),
+    },
+  }
+}
+
+describe('createOpenAICompatibleResponse', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    installWindowMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete (globalThis as any).window
+  })
+
+  it('sends a safe Z.ai Coding Plan model id', async () => {
+    const settingsStore = useSettingsStore()
+    settingsStore.updateSetting('aiProvider', 'zai')
+    settingsStore.updateSetting('assistantModel', 'gpt-4o-mini')
+
+    const create = vi.fn().mockResolvedValue({ choices: [] })
+    const client = {
+      chat: {
+        completions: {
+          create,
+        },
+      },
+    }
+
+    await createOpenAICompatibleResponse(
+      'zai',
+      () => client as any,
+      [
+        {
+          role: 'user',
+          content: [{ type: 'input_text', text: 'hello' }],
+        } as any,
+      ],
+      false
+    )
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'glm-5.1',
+      }),
+      expect.any(Object)
+    )
+  })
+
+  it('sends a safe MiniMax text model id', async () => {
+    const settingsStore = useSettingsStore()
+    settingsStore.updateSetting('aiProvider', 'minimax')
+    settingsStore.updateSetting('VITE_MINIMAX_API_KEY', 'sk-test')
+    settingsStore.updateSetting('assistantModel', 'gpt-4o-mini')
+
+    const request = vi.fn().mockResolvedValue({
+      success: true,
+      status: 200,
+      data: {
+        id: 'chatcmpl-test',
+        choices: [
+          {
+            message: {
+              content: 'hello back',
+            },
+          },
+        ],
+      },
+    })
+    ;(globalThis as any).window.httpAPI = {
+      request,
+    }
+    const getClient = vi.fn()
+
+    await createOpenAICompatibleResponse(
+      'minimax',
+      getClient as any,
+      [
+        {
+          role: 'user',
+          content: [{ type: 'input_text', text: 'hello' }],
+        } as any,
+      ],
+      false
+    )
+
+    expect(getClient).not.toHaveBeenCalled()
+    expect(request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'POST',
+        url: 'https://api.minimax.io/v1/chat/completions',
+        headers: {
+          Authorization: 'Bearer sk-test',
+          'Content-Type': 'application/json',
+        },
+        data: expect.objectContaining({
+          model: 'MiniMax-M2.7',
+          reasoning_split: true,
+          stream: false,
+        }),
+      })
+    )
+    expect(request.mock.calls[0][0].headers['x-stainless-os']).toBeUndefined()
+  })
+
+  it('does not send system-role messages to MiniMax continuations', async () => {
+    const settingsStore = useSettingsStore()
+    settingsStore.updateSetting('aiProvider', 'minimax')
+    settingsStore.updateSetting('VITE_MINIMAX_API_KEY', 'sk-test')
+
+    const request = vi.fn().mockResolvedValue({
+      success: true,
+      status: 200,
+      data: {
+        id: 'chatcmpl-test',
+        choices: [{ message: { content: 'В памяти пусто.' } }],
+      },
+    })
+    ;(globalThis as any).window.httpAPI = {
+      request,
+    }
+
+    await createOpenAICompatibleResponse(
+      'minimax',
+      vi.fn() as any,
+      [
+        {
+          role: 'user',
+          content: [{ type: 'input_text', text: 'Помнишь имена?' }],
+        } as any,
+        {
+          role: 'assistant',
+          content: [],
+          tool_calls: [
+            {
+              call_id: 'call_1',
+              name: 'recall_memories',
+              arguments: { query: 'cats names' },
+            },
+          ],
+        } as any,
+        {
+          role: 'system',
+          content: [{ type: 'input_text', text: '🧠 Let me think back...' }],
+        } as any,
+        {
+          type: 'function_call_output',
+          call_id: 'call_1',
+          output: '[]',
+        } as any,
+      ],
+      true,
+      'Core persona instructions'
+    )
+
+    const messages = request.mock.calls[0][0].data.messages
+    expect(messages.some((message: any) => message.role === 'system')).toBe(
+      false
+    )
+    expect(messages[0].role).toBe('user')
+    expect(messages[0].content).toContain('Core persona instructions')
+    expect(messages[0].content).not.toContain('Let me think back')
+    expect(messages.map((message: any) => message.role)).toEqual([
+      'user',
+      'assistant',
+      'tool',
+    ])
+  })
+
+  it('strips MiniMax think blocks before rendering content', () => {
+    expect(
+      stripReasoningFromMiniMaxContent(
+        '<think>The user asks whether I played it.</think>\n\nНет, я сама в неё не играла.'
+      )
+    ).toBe('Нет, я сама в неё не играла.')
+  })
+})

--- a/src/services/llmProviders/__tests__/providerCatalog.test.ts
+++ b/src/services/llmProviders/__tests__/providerCatalog.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MINIMAX_TEXT_MODELS,
+  ZAI_CODING_MODELS,
+  getSafeProviderModel,
+  getStaticModelsForProvider,
+} from '../providerCatalog'
+
+describe('providerCatalog', () => {
+  it('exposes Z.ai Coding Plan models with API model ids', () => {
+    expect(getStaticModelsForProvider('zai').map(model => model.id)).toEqual([
+      'glm-5.1',
+      'glm-5-turbo',
+      'glm-4.7',
+      'glm-4.5-air',
+    ])
+    expect(ZAI_CODING_MODELS[0]?.displayName).toBe('GLM-5.1')
+  })
+
+  it('falls back to the Z.ai default for non-coding model ids', () => {
+    expect(getSafeProviderModel('zai', 'gpt-4o-mini')).toBe('glm-5.1')
+    expect(getSafeProviderModel('zai', 'glm-5-turbo')).toBe('glm-5-turbo')
+  })
+
+  it('exposes MiniMax text models with API model ids', () => {
+    expect(
+      getStaticModelsForProvider('minimax').map(model => model.id)
+    ).toEqual([
+      'MiniMax-M2.7',
+      'MiniMax-M2.7-highspeed',
+      'MiniMax-M2.5',
+      'MiniMax-M2.5-highspeed',
+      'MiniMax-M2.1',
+      'MiniMax-M2.1-highspeed',
+      'MiniMax-M2',
+    ])
+    expect(MINIMAX_TEXT_MODELS[0]?.displayName).toBe('MiniMax M2.7')
+  })
+
+  it('falls back to the MiniMax default for non-MiniMax model ids', () => {
+    expect(getSafeProviderModel('minimax', 'gpt-4o-mini')).toBe('MiniMax-M2.7')
+    expect(getSafeProviderModel('minimax', 'MiniMax-M2.7-highspeed')).toBe(
+      'MiniMax-M2.7-highspeed'
+    )
+  })
+})

--- a/src/services/llmProviders/minimax.ts
+++ b/src/services/llmProviders/minimax.ts
@@ -1,12 +1,97 @@
 import type OpenAI from 'openai'
 import { getMiniMaxClient } from '../apiClients'
-import {
-  createOpenAICompatibleResponse,
-  listOpenAICompatibleModels,
-} from './openAICompatible'
+import { useSettingsStore } from '../../stores/settingsStore'
+import { createOpenAICompatibleResponse } from './openAICompatible'
+import { MINIMAX_OPENAI_BASE_URL, MINIMAX_TEXT_MODELS } from './providerCatalog'
+
+function createMiniMaxModel(id: string): OpenAI.Models.Model {
+  return {
+    id,
+    object: 'model',
+    created: 0,
+    owned_by: 'minimax',
+  } as OpenAI.Models.Model
+}
+
+function listStaticMiniMaxTextModels(): OpenAI.Models.Model[] {
+  return MINIMAX_TEXT_MODELS.map(model => createMiniMaxModel(model.id))
+}
+
+function isAuthError(error: any): boolean {
+  return error?.status === 401 || error?.status === 403
+}
+
+function normalizeBaseUrl(baseURL: string): string {
+  return baseURL.replace(/\/+$/, '')
+}
+
+function normalizeMiniMaxModels(data: any): OpenAI.Models.Model[] {
+  const models = Array.isArray(data?.data) ? data.data : []
+  return models.filter((model: any) => typeof model?.id === 'string')
+}
+
+function filterMiniMaxTextModels(
+  models: OpenAI.Models.Model[]
+): OpenAI.Models.Model[] {
+  const textModelIds = new Set(MINIMAX_TEXT_MODELS.map(model => model.id))
+  return models.filter(model => textModelIds.has(model.id))
+}
+
+async function fetchMiniMaxModelsViaMain(
+  apiKey: string,
+  baseURL: string
+): Promise<OpenAI.Models.Model[]> {
+  if (typeof window === 'undefined' || !window.httpAPI) {
+    throw new Error('Electron HTTP bridge is unavailable.')
+  }
+
+  const response = await window.httpAPI.request({
+    url: `${normalizeBaseUrl(baseURL)}/models`,
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+    timeout: 10 * 1000,
+  })
+
+  if (!response.success) {
+    throw new Error(response.error || 'MiniMax models request failed.')
+  }
+
+  if (response.status && response.status >= 400) {
+    const error = new Error(
+      `MiniMax models request failed with status ${response.status}.`
+    ) as Error & { status?: number; data?: any }
+    error.status = response.status
+    error.data = response.data
+    throw error
+  }
+
+  return normalizeMiniMaxModels(response.data)
+}
+
+export async function listMiniMaxModelsForConfig(
+  apiKey: string,
+  baseURL = MINIMAX_OPENAI_BASE_URL
+): Promise<OpenAI.Models.Model[]> {
+  try {
+    const models = await fetchMiniMaxModelsViaMain(apiKey, baseURL)
+    const textModels = filterMiniMaxTextModels(models)
+    return textModels.length > 0 ? textModels : listStaticMiniMaxTextModels()
+  } catch (error) {
+    if (isAuthError(error)) {
+      throw error
+    }
+    return listStaticMiniMaxTextModels()
+  }
+}
 
 export const listMiniMaxModels = async (): Promise<OpenAI.Models.Model[]> => {
-  return listOpenAICompatibleModels(getMiniMaxClient)
+  const settings = useSettingsStore().config
+  return listMiniMaxModelsForConfig(
+    settings.VITE_MINIMAX_API_KEY,
+    settings.minimaxBaseUrl || MINIMAX_OPENAI_BASE_URL
+  )
 }
 
 export const createMiniMaxResponse = async (

--- a/src/services/llmProviders/openAICompatible.ts
+++ b/src/services/llmProviders/openAICompatible.ts
@@ -1,8 +1,14 @@
 import type OpenAI from 'openai'
 import { useSettingsStore } from '../../stores/settingsStore'
-import { convertLocalLLMStreamToResponsesFormat } from './streamAdapters'
+import {
+  convertChatCompletionToResponsesFormat,
+  convertLocalLLMStreamToResponsesFormat,
+} from './streamAdapters'
 import { buildToolsForProvider } from './tools'
-import { PROVIDER_CONFIGS } from './providerCatalog'
+import {
+  MINIMAX_OPENAI_BASE_URL,
+  getSafeProviderModel,
+} from './providerCatalog'
 
 type OpenAIClientGetter = () => OpenAI
 type OpenAICompatibleProviderKey = 'zai' | 'minimax'
@@ -115,25 +121,68 @@ function addCustomInstructions(
   messages: OpenAI.Chat.ChatCompletionMessageParam[],
   customInstructions?: string
 ): void {
+  for (let index = messages.length - 1; index >= 0; index--) {
+    if (messages[index].role === 'system') {
+      messages.splice(index, 1)
+    }
+  }
+
   if (!customInstructions) {
     return
   }
 
-  const systemIndex = messages.findIndex(message => message.role === 'system')
-  if (systemIndex === -1) {
-    messages.unshift({
-      role: 'system',
-      content: customInstructions,
-    })
-    return
+  messages.unshift({
+    role: 'system',
+    content: customInstructions,
+  })
+}
+
+function prepareMiniMaxMessages(
+  messages: OpenAI.Chat.ChatCompletionMessageParam[],
+  customInstructions?: string
+): OpenAI.Chat.ChatCompletionMessageParam[] {
+  const instructionBlock = customInstructions?.trim() || ''
+  const nonSystemMessages = messages.filter(
+    message => message.role !== 'system'
+  )
+
+  if (!instructionBlock) {
+    return nonSystemMessages
   }
 
-  const existing = String(messages[systemIndex]?.content || '').trim()
-  if (!existing.includes(customInstructions.trim())) {
-    ;(messages[systemIndex] as any).content = existing
-      ? `${customInstructions}\n\n${existing}`
-      : customInstructions
+  const firstUserMessage = nonSystemMessages.find(
+    message => message.role === 'user'
+  ) as any
+
+  if (firstUserMessage) {
+    const originalContent =
+      typeof firstUserMessage.content === 'string'
+        ? firstUserMessage.content
+        : JSON.stringify(firstUserMessage.content || '')
+    firstUserMessage.content = `${instructionBlock}\n\n${originalContent}`
+    return nonSystemMessages
   }
+
+  return [
+    {
+      role: 'user',
+      content: instructionBlock,
+    },
+    ...nonSystemMessages,
+  ]
+}
+
+function prepareChatMessagesForProvider(
+  provider: OpenAICompatibleProviderKey,
+  messages: OpenAI.Chat.ChatCompletionMessageParam[],
+  customInstructions?: string
+): OpenAI.Chat.ChatCompletionMessageParam[] {
+  if (provider === 'minimax') {
+    return prepareMiniMaxMessages(messages, customInstructions)
+  }
+
+  addCustomInstructions(messages, customInstructions)
+  return messages
 }
 
 function convertToolsForChatCompletions(finalToolsForApi: any[]) {
@@ -163,6 +212,71 @@ export async function listOpenAICompatibleModels(
   return modelsPage.data.sort((a, b) => a.id.localeCompare(b.id))
 }
 
+export function stripReasoningFromMiniMaxContent(content: string): string {
+  return content
+    .replace(/<think>[\s\S]*?<\/think>/gi, '')
+    .replace(
+      /^\s*(?:reasoning|thinking)[\s_-]*content\s*:\s*[\s\S]*?\n{2,}/i,
+      ''
+    )
+    .trim()
+}
+
+function normalizeBaseUrl(baseURL: string): string {
+  return baseURL.replace(/\/+$/, '')
+}
+
+export async function createMiniMaxChatCompletionViaMain(
+  params: OpenAI.Chat.ChatCompletionCreateParams
+): Promise<any> {
+  const settings = useSettingsStore().config
+  if (!settings.VITE_MINIMAX_API_KEY?.trim()) {
+    throw new Error('MiniMax API Key is not configured.')
+  }
+  if (typeof window === 'undefined' || !window.httpAPI) {
+    throw new Error('Electron HTTP bridge is unavailable.')
+  }
+
+  const body = {
+    ...params,
+    stream: false,
+    reasoning_split: true,
+  }
+
+  const response = await window.httpAPI.request({
+    url: `${normalizeBaseUrl(settings.minimaxBaseUrl || MINIMAX_OPENAI_BASE_URL)}/chat/completions`,
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${settings.VITE_MINIMAX_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    data: body,
+    timeout: 120 * 1000,
+  })
+
+  if (!response.success) {
+    throw new Error(response.error || 'MiniMax chat completion request failed.')
+  }
+
+  if (response.status && response.status >= 400) {
+    const message =
+      response.data?.error?.message ||
+      response.data?.message ||
+      `MiniMax chat completion failed with status ${response.status}.`
+    const error = new Error(message) as Error & { status?: number; data?: any }
+    error.status = response.status
+    error.data = response.data
+    throw error
+  }
+
+  const data = response.data
+  const message = data?.choices?.[0]?.message
+  if (message && typeof message.content === 'string') {
+    message.content = stripReasoningFromMiniMaxContent(message.content)
+  }
+  return data
+}
+
 export async function createOpenAICompatibleResponse(
   provider: OpenAICompatibleProviderKey,
   getClient: OpenAIClientGetter,
@@ -171,20 +285,20 @@ export async function createOpenAICompatibleResponse(
   customInstructions?: string,
   signal?: AbortSignal
 ): Promise<any> {
-  const client = getClient()
   const settings = useSettingsStore().config
   const finalToolsForApi = await buildToolsForProvider()
-  const messages = convertResponsesInputToChatMessages(input)
-
-  addCustomInstructions(messages, customInstructions)
+  const messages = prepareChatMessagesForProvider(
+    provider,
+    convertResponsesInputToChatMessages(input),
+    customInstructions
+  )
 
   console.log(
     `[${provider}] Final messages:`,
     JSON.stringify(messages, null, 2)
   )
 
-  const model =
-    settings.assistantModel || PROVIDER_CONFIGS[provider].defaultModel
+  const model = getSafeProviderModel(provider, settings.assistantModel)
   const params: OpenAI.Chat.ChatCompletionCreateParams = {
     model,
     messages,
@@ -197,6 +311,18 @@ export async function createOpenAICompatibleResponse(
     tools: convertToolsForChatCompletions(finalToolsForApi),
     stream,
   }
+
+  if (provider === 'minimax') {
+    if (signal?.aborted) {
+      throw new DOMException('The operation was aborted.', 'AbortError')
+    }
+    const completion = await createMiniMaxChatCompletionViaMain(params)
+    return stream
+      ? convertChatCompletionToResponsesFormat(completion, provider)
+      : completion
+  }
+
+  const client = getClient()
 
   if (stream) {
     const chatStream = await client.chat.completions.create(params as any, {

--- a/src/services/llmProviders/providerCatalog.ts
+++ b/src/services/llmProviders/providerCatalog.ts
@@ -14,6 +14,28 @@ export interface ProviderConfig {
   nativeWebSearch: boolean
 }
 
+export interface ProviderModelDefinition {
+  id: string
+  displayName: string
+}
+
+export const ZAI_CODING_MODELS: ProviderModelDefinition[] = [
+  { id: 'glm-5.1', displayName: 'GLM-5.1' },
+  { id: 'glm-5-turbo', displayName: 'GLM-5-Turbo' },
+  { id: 'glm-4.7', displayName: 'GLM-4.7' },
+  { id: 'glm-4.5-air', displayName: 'GLM-4.5-Air' },
+]
+
+export const MINIMAX_TEXT_MODELS: ProviderModelDefinition[] = [
+  { id: 'MiniMax-M2.7', displayName: 'MiniMax M2.7' },
+  { id: 'MiniMax-M2.7-highspeed', displayName: 'MiniMax M2.7 High-Speed' },
+  { id: 'MiniMax-M2.5', displayName: 'MiniMax M2.5' },
+  { id: 'MiniMax-M2.5-highspeed', displayName: 'MiniMax M2.5 High-Speed' },
+  { id: 'MiniMax-M2.1', displayName: 'MiniMax M2.1' },
+  { id: 'MiniMax-M2.1-highspeed', displayName: 'MiniMax M2.1 High-Speed' },
+  { id: 'MiniMax-M2', displayName: 'MiniMax M2' },
+]
+
 export const PROVIDER_CONFIGS: Record<AIProviderKey, ProviderConfig> = {
   openai: {
     displayName: 'OpenAI',
@@ -60,6 +82,40 @@ export const CHAT_COMPLETIONS_PROVIDERS: ChatCompletionsProviderKey[] = [
 
 export function getProviderDisplayName(provider: string): string {
   return PROVIDER_CONFIGS[provider as AIProviderKey]?.displayName || provider
+}
+
+export function getStaticModelsForProvider(
+  provider: string
+): ProviderModelDefinition[] {
+  if (provider === 'zai') {
+    return ZAI_CODING_MODELS
+  }
+  if (provider === 'minimax') {
+    return MINIMAX_TEXT_MODELS
+  }
+  return []
+}
+
+export function isKnownProviderModel(provider: string, model: string): boolean {
+  const staticModels = getStaticModelsForProvider(provider)
+  if (staticModels.length === 0) {
+    return true
+  }
+  return staticModels.some(staticModel => staticModel.id === model)
+}
+
+export function getSafeProviderModel(
+  provider: string,
+  configuredModel?: string
+): string {
+  const fallback =
+    PROVIDER_CONFIGS[provider as AIProviderKey]?.defaultModel ||
+    PROVIDER_CONFIGS.openai.defaultModel
+  const trimmedModel = configuredModel?.trim()
+  if (!trimmedModel) {
+    return fallback
+  }
+  return isKnownProviderModel(provider, trimmedModel) ? trimmedModel : fallback
 }
 
 export function isChatCompletionsProvider(

--- a/src/services/llmProviders/streamAdapters.ts
+++ b/src/services/llmProviders/streamAdapters.ts
@@ -198,6 +198,124 @@ export async function* convertLocalLLMStreamToResponsesFormat(
   }
 }
 
+export async function* convertChatCompletionToResponsesFormat(
+  completion: any,
+  provider: 'zai' | 'minimax'
+) {
+  const responseId = completion?.id || `${provider}-${Date.now()}`
+  const messageItemId = `message-${Date.now()}`
+  const choice = completion?.choices?.[0]
+  const message = choice?.message || {}
+  const content = typeof message.content === 'string' ? message.content : ''
+
+  yield {
+    type: 'response.created',
+    response: {
+      id: responseId,
+      object: 'realtime.response',
+      status: 'in_progress',
+      output: [],
+    },
+  }
+
+  yield {
+    type: 'response.output_item.added',
+    response_id: responseId,
+    item_id: messageItemId,
+    item: {
+      id: messageItemId,
+      type: 'message',
+      role: 'assistant',
+      content: [],
+    },
+  }
+
+  if (content) {
+    yield {
+      type: 'response.output_text.delta',
+      response_id: responseId,
+      item_id: messageItemId,
+      output_index: 0,
+      content_index: 0,
+      delta: content,
+    }
+  }
+
+  for (const [index, toolCall] of (message.tool_calls || []).entries()) {
+    const toolCallId = `tool-${index}`
+    const rawArguments = toolCall.function?.arguments || ''
+    let parsedArguments: any = {}
+
+    if (rawArguments.trim()) {
+      try {
+        parsedArguments = JSON.parse(rawArguments)
+      } catch (error) {
+        console.error(
+          `[${provider}] Failed to parse tool arguments:`,
+          rawArguments,
+          error
+        )
+      }
+    }
+
+    yield {
+      type: 'response.output_item.added',
+      response_id: responseId,
+      item_id: toolCallId,
+      item: {
+        id: toolCallId,
+        type: 'function_call',
+        name: toolCall.function?.name || '',
+        arguments: '',
+      },
+    }
+
+    if (rawArguments) {
+      yield {
+        type: 'response.function_call_arguments.delta',
+        response_id: responseId,
+        item_id: toolCallId,
+        delta: rawArguments,
+      }
+    }
+
+    yield {
+      type: 'response.output_item.done',
+      response_id: responseId,
+      item_id: toolCallId,
+      item: {
+        id: toolCallId,
+        call_id: toolCall.id || toolCallId,
+        type: 'function_call',
+        name: toolCall.function?.name || '',
+        arguments: parsedArguments,
+      },
+    }
+  }
+
+  yield {
+    type: 'response.output_item.done',
+    response_id: responseId,
+    item_id: messageItemId,
+    item: {
+      id: messageItemId,
+      type: 'message',
+      role: 'assistant',
+      content: [],
+    },
+  }
+
+  yield {
+    type: 'response.done',
+    response: {
+      id: responseId,
+      object: 'realtime.response',
+      status: 'completed',
+      output: [],
+    },
+  }
+}
+
 export async function* convertOpenRouterStreamToResponsesFormat(stream: any) {
   let responseId = `openrouter-${Date.now()}`
   let messageItemId = `message-${Date.now()}`

--- a/src/services/llmProviders/zai.ts
+++ b/src/services/llmProviders/zai.ts
@@ -4,9 +4,37 @@ import {
   createOpenAICompatibleResponse,
   listOpenAICompatibleModels,
 } from './openAICompatible'
+import { ZAI_CODING_MODELS } from './providerCatalog'
+
+function createZAIModel(id: string): OpenAI.Models.Model {
+  return {
+    id,
+    object: 'model',
+    created: 0,
+    owned_by: 'zai',
+  } as OpenAI.Models.Model
+}
+
+function listStaticZAICodingModels(): OpenAI.Models.Model[] {
+  return ZAI_CODING_MODELS.map(model => createZAIModel(model.id))
+}
+
+function isAuthError(error: any): boolean {
+  return error?.status === 401 || error?.status === 403
+}
 
 export const listZAIModels = async (): Promise<OpenAI.Models.Model[]> => {
-  return listOpenAICompatibleModels(getZAIClient)
+  try {
+    const models = await listOpenAICompatibleModels(getZAIClient)
+    const codingModelIds = new Set(ZAI_CODING_MODELS.map(model => model.id))
+    const codingModels = models.filter(model => codingModelIds.has(model.id))
+    return codingModels.length > 0 ? codingModels : listStaticZAICodingModels()
+  } catch (error) {
+    if (isAuthError(error)) {
+      throw error
+    }
+    return listStaticZAICodingModels()
+  }
 }
 
 export const createZAIResponse = async (

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -9,6 +9,7 @@ import {
   PROVIDER_CONFIGS,
   ZAI_CODING_BASE_URL,
   getProviderDisplayName,
+  getSafeProviderModel,
   type AIProviderKey,
 } from '../services/llmProviders/providerCatalog'
 
@@ -317,6 +318,24 @@ export const useSettingsStore = defineStore('settings', () => {
     ] as const
     if (!validAIProviders.includes(validated.aiProvider as any)) {
       validated.aiProvider = 'openai'
+    }
+
+    const safeAssistantModel = getSafeProviderModel(
+      validated.aiProvider,
+      validated.assistantModel
+    )
+    if (safeAssistantModel !== validated.assistantModel) {
+      validated.assistantModel = safeAssistantModel
+      migrated = true
+    }
+
+    const safeSummarizationModel = getSafeProviderModel(
+      validated.aiProvider,
+      validated.SUMMARIZATION_MODEL
+    )
+    if (safeSummarizationModel !== validated.SUMMARIZATION_MODEL) {
+      validated.SUMMARIZATION_MODEL = safeSummarizationModel
+      migrated = true
     }
 
     if (


### PR DESCRIPTION
## Summary
This PR stabilizes the new Z.ai and MiniMax provider paths.

It adds provider-specific model catalogs and safe model selection so saved OpenAI model ids do not leak into Z.ai or MiniMax requests. Z.ai model listing now falls back to the Coding Plan model list when the endpoint is unavailable or unhelpful.

MiniMax requests now avoid browser-side OpenAI SDK calls that trigger CORS failures from Stainless headers. Model discovery, primary chat completions, summarization, and context analysis go through the Electron HTTP bridge instead.

The MiniMax chat path also filters reasoning output before it reaches chat or TTS, avoids unsupported `system` role messages in tool-call continuations, and fixes the audio-state race where synthetic one-shot responses could flip `SPEAKING` back to `IDLE` before playback actually started.

## Impact
Users can select valid Z.ai and MiniMax models in settings, use MiniMax without CORS failures, continue tool-call conversations, and get cleaner spoken/chat responses without reasoning text leaking into the UI.
