### PR TITLE
Harden provider inference pipeline

### DIFF
--- a/electron/main/ipcManager.ts
+++ b/electron/main/ipcManager.ts
@@ -6,6 +6,7 @@ import {
   app,
   BrowserWindow,
   dialog,
+  type WebContents,
 } from 'electron'
 import { mkdir, writeFile } from 'node:fs/promises'
 import path from 'node:path'
@@ -20,6 +21,30 @@ import {
 
 function isBrowserContextToolEnabled(settings: any): boolean {
   return settings?.assistantTools?.includes('browser_context') || false
+}
+
+const activeHttpStreams = new Map<string, AbortController>()
+
+function sendHttpStreamEvent(
+  sender: WebContents,
+  requestId: string,
+  payload: Record<string, any>
+): void {
+  if (sender.isDestroyed()) {
+    return
+  }
+  sender.send(`http:stream:event:${requestId}`, payload)
+}
+
+function readSseDataFrame(frame: string): string | null {
+  const data = frame
+    .split(/\r?\n/)
+    .filter(line => line.startsWith('data:'))
+    .map(line => line.slice('data:'.length).trimStart())
+    .join('\n')
+    .trim()
+
+  return data || null
 }
 import {
   saveMemoryLocal,
@@ -1085,50 +1110,232 @@ export function registerIPCHandlers(): void {
   })
 
   // HTTP request handler to bypass CORS
-  ipcMain.handle('http:request', async (event, args: {
-    url: string
-    method?: string
-    headers?: Record<string, string>
-    params?: Record<string, any>
-    data?: any
-    timeout?: number
-  }) => {
-    try {
-      const { url, method = 'GET', headers = {}, params, data, timeout = 15000 } = args
-      
-      console.log(`[IPC http:request] Making ${method} request to:`, url)
-      
-      const response = await axios({
-        url,
-        method,
-        headers,
-        params,
-        data,
-        timeout,
-        validateStatus: () => true // Don't throw on HTTP error status codes
-      })
-
-      return {
-        success: true,
-        data: response.data,
-        status: response.status,
-        statusText: response.statusText,
-        headers: response.headers
+  ipcMain.handle(
+    'http:request',
+    async (
+      event,
+      args: {
+        url: string
+        method?: string
+        headers?: Record<string, string>
+        params?: Record<string, any>
+        data?: any
+        timeout?: number
       }
-    } catch (error: any) {
-      console.error('[IPC http:request] Error:', error)
-      return {
-        success: false,
-        error: error.message,
-        code: error.code,
-        response: error.response ? {
-          status: error.response.status,
-          statusText: error.response.statusText,
-          data: error.response.data
-        } : null
+    ) => {
+      try {
+        const {
+          url,
+          method = 'GET',
+          headers = {},
+          params,
+          data,
+          timeout = 15000,
+        } = args
+
+        console.log(`[IPC http:request] Making ${method} request to:`, url)
+
+        const response = await axios({
+          url,
+          method,
+          headers,
+          params,
+          data,
+          timeout,
+          validateStatus: () => true, // Don't throw on HTTP error status codes
+        })
+
+        return {
+          success: true,
+          data: response.data,
+          status: response.status,
+          statusText: response.statusText,
+          headers: response.headers,
+        }
+      } catch (error: any) {
+        console.error('[IPC http:request] Error:', error)
+        return {
+          success: false,
+          error: error.message,
+          code: error.code,
+          response: error.response
+            ? {
+                status: error.response.status,
+                statusText: error.response.statusText,
+                data: error.response.data,
+              }
+            : null,
+        }
       }
     }
-  })
+  )
+
+  ipcMain.handle(
+    'http:stream-start',
+    async (
+      event,
+      args: {
+        requestId: string
+        url: string
+        method?: string
+        headers?: Record<string, string>
+        params?: Record<string, any>
+        data?: any
+        timeout?: number
+      }
+    ) => {
+      const {
+        requestId,
+        url,
+        method = 'GET',
+        headers = {},
+        params,
+        data,
+        timeout = 120000,
+      } = args || {}
+
+      if (!requestId || !url) {
+        return {
+          success: false,
+          error: 'Stream request id and URL are required.',
+        }
+      }
+
+      const abortController = new AbortController()
+      activeHttpStreams.set(requestId, abortController)
+      const sender = event.sender
+
+      void (async () => {
+        let streamDone = false
+
+        const finishStream = () => {
+          if (streamDone) {
+            return
+          }
+          streamDone = true
+          activeHttpStreams.delete(requestId)
+          sendHttpStreamEvent(sender, requestId, { type: 'done' })
+        }
+
+        const failStream = (
+          error: any,
+          status?: number,
+          responseData?: any
+        ) => {
+          activeHttpStreams.delete(requestId)
+          sendHttpStreamEvent(sender, requestId, {
+            type: 'error',
+            error:
+              error?.message ||
+              responseData?.error?.message ||
+              responseData?.message ||
+              'HTTP stream request failed.',
+            status,
+            data: responseData,
+          })
+        }
+
+        try {
+          console.log(`[IPC http:stream] Making ${method} request to:`, url)
+
+          const response = await axios({
+            url,
+            method,
+            headers,
+            params,
+            data,
+            timeout,
+            responseType: 'stream',
+            signal: abortController.signal,
+            validateStatus: () => true,
+          })
+
+          if (response.status >= 400) {
+            let errorBody = ''
+            for await (const chunk of response.data as any) {
+              errorBody += Buffer.from(chunk).toString('utf8')
+              if (errorBody.length > 65536) {
+                break
+              }
+            }
+
+            let parsedBody: any = errorBody
+            try {
+              parsedBody = JSON.parse(errorBody)
+            } catch {
+              // Keep the raw upstream body when it is not JSON.
+            }
+
+            failStream(
+              new Error(`HTTP stream failed with status ${response.status}.`),
+              response.status,
+              parsedBody
+            )
+            return
+          }
+
+          let buffer = ''
+          for await (const chunk of response.data as any) {
+            buffer += Buffer.from(chunk).toString('utf8')
+
+            let separatorIndex = buffer.search(/\r?\n\r?\n/)
+            while (separatorIndex !== -1) {
+              const frame = buffer.slice(0, separatorIndex)
+              const separator = buffer.match(/\r?\n\r?\n/)
+              buffer = buffer.slice(
+                separatorIndex + (separator?.[0]?.length || 2)
+              )
+
+              const dataFrame = readSseDataFrame(frame)
+              if (dataFrame === '[DONE]') {
+                finishStream()
+                return
+              }
+              if (dataFrame) {
+                sendHttpStreamEvent(sender, requestId, {
+                  type: 'chunk',
+                  data: JSON.parse(dataFrame),
+                })
+              }
+
+              separatorIndex = buffer.search(/\r?\n\r?\n/)
+            }
+          }
+
+          const trailingFrame = readSseDataFrame(buffer)
+          if (trailingFrame && trailingFrame !== '[DONE]') {
+            sendHttpStreamEvent(sender, requestId, {
+              type: 'chunk',
+              data: JSON.parse(trailingFrame),
+            })
+          }
+
+          finishStream()
+        } catch (error: any) {
+          if (abortController.signal.aborted) {
+            finishStream()
+            return
+          }
+          console.error('[IPC http:stream] Error:', error)
+          failStream(error, error?.response?.status, error?.response?.data)
+        }
+      })()
+
+      return { success: true }
+    }
+  )
+
+  ipcMain.handle(
+    'http:stream-cancel',
+    async (event, args: { requestId: string }) => {
+      const abortController = activeHttpStreams.get(args?.requestId)
+      if (abortController) {
+        abortController.abort()
+        activeHttpStreams.delete(args.requestId)
+      }
+      return { success: true }
+    }
+  )
 }
 
 let googleIPCHandlersRegistered = false

--- a/src/components/wizard/OnboardingWizard.vue
+++ b/src/components/wizard/OnboardingWizard.vue
@@ -61,11 +61,13 @@ import FinalSetupStep from './steps/FinalSetupStep.vue'
 import OpenAI from 'openai'
 import {
   MINIMAX_OPENAI_BASE_URL,
-  ZAI_CODING_MODELS,
   ZAI_CODING_BASE_URL,
   type AIProviderKey,
 } from '../../services/llmProviders/providerCatalog'
 import { listMiniMaxModelsForConfig } from '../../services/llmProviders/minimax'
+import { listOpenAIModelsForConfig } from '../../services/llmProviders/openai'
+import { listOpenRouterModelsForConfig } from '../../services/llmProviders/openrouter'
+import { listZAIModelsForConfig } from '../../services/llmProviders/zai'
 
 const step = ref(1)
 const settingsStore = useSettingsStore()
@@ -92,10 +94,6 @@ const formData = reactive({
   availableModels: [] as string[],
   localSttLanguage: 'auto',
 })
-
-function isAuthError(error: any): boolean {
-  return error?.status === 401 || error?.status === 403
-}
 
 const isTesting = reactive({
   openai: false,
@@ -235,11 +233,22 @@ const fetchAvailableModels = async () => {
       return
     }
 
+    if (formData.aiProvider === 'zai') {
+      const models = await listZAIModelsForConfig(
+        formData.VITE_ZAI_API_KEY,
+        baseURL
+      )
+      formData.availableModels = models.map(model => model.id)
+
+      if (formData.availableModels.length > 0) {
+        formData.assistantModel = formData.availableModels[0]
+        formData.summarizationModel = formData.availableModels[0]
+      }
+      return
+    }
+
     const tempClient = new OpenAI({
-      apiKey:
-        formData.aiProvider === 'zai'
-          ? formData.VITE_ZAI_API_KEY
-          : formData.aiProvider,
+      apiKey: formData.aiProvider,
       baseURL,
       dangerouslyAllowBrowser: true,
     })
@@ -252,12 +261,6 @@ const fetchAvailableModels = async () => {
       formData.summarizationModel = formData.availableModels[0]
     }
   } catch (error) {
-    if (formData.aiProvider === 'zai' && !isAuthError(error)) {
-      formData.availableModels = ZAI_CODING_MODELS.map(model => model.id)
-      formData.assistantModel = formData.availableModels[0] || 'glm-5.1'
-      formData.summarizationModel = formData.availableModels[0] || 'glm-5.1'
-      return
-    }
     console.error('Failed to fetch models:', error)
     formData.availableModels = []
     throw error
@@ -276,12 +279,7 @@ const testOpenAIKey = async () => {
   testResult.openai.success = false
 
   try {
-    const tempClient = new OpenAI({
-      apiKey: formData.VITE_OPENAI_API_KEY,
-      dangerouslyAllowBrowser: true,
-    })
-
-    await tempClient.models.list()
+    await listOpenAIModelsForConfig(formData.VITE_OPENAI_API_KEY)
     testResult.openai.success = true
   } catch (e: any) {
     testResult.openai.error = 'API Key is invalid or has no permissions.'
@@ -307,13 +305,7 @@ const testOpenRouterKey = async () => {
   testResult.openrouter.success = false
 
   try {
-    const tempClient = new OpenAI({
-      apiKey: formData.VITE_OPENROUTER_API_KEY,
-      baseURL: 'https://openrouter.ai/api/v1',
-      dangerouslyAllowBrowser: true,
-    })
-
-    await tempClient.models.list()
+    await listOpenRouterModelsForConfig(formData.VITE_OPENROUTER_API_KEY)
     testResult.openrouter.success = true
   } catch (e: any) {
     testResult.openrouter.error = 'API Key is invalid or has no permissions.'

--- a/src/modules/conversation/__tests__/apiInputBuilder.test.ts
+++ b/src/modules/conversation/__tests__/apiInputBuilder.test.ts
@@ -90,6 +90,51 @@ describe('createApiInputBuilder', () => {
     })
   })
 
+  it('keeps UI system status messages out of inference payloads', async () => {
+    const history: ConversationHistoryMessage[] = [
+      {
+        role: 'tool',
+        tool_call_id: 'call_123',
+        content: '[]',
+      },
+      {
+        role: 'system',
+        content: [{ type: 'app_text', text: '🧠 Let me think back...' }],
+      },
+      {
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          {
+            id: 'call_123',
+            type: 'function',
+            function: {
+              name: 'recall_memories',
+              arguments: '{"query":"cats"}',
+            },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: 'Do you remember my cats?',
+      },
+    ]
+
+    const builder = createApiInputBuilder(
+      buildDependencies({ history, getAiProvider: () => 'minimax' })
+    )
+    const result = await builder.build({ isNewChain: false })
+
+    expect(result.some((item: any) => item.role === 'system')).toBe(false)
+    expect(JSON.stringify(result)).not.toContain('Let me think back')
+    expect(result.map((item: any) => item.role || item.type)).toEqual([
+      'user',
+      'assistant',
+      'function_call_output',
+    ])
+  })
+
   it('converts last user image into input_image part', async () => {
     const history: ConversationHistoryMessage[] = [
       {

--- a/src/modules/conversation/apiInputBuilder.ts
+++ b/src/modules/conversation/apiInputBuilder.ts
@@ -56,6 +56,10 @@ export function createApiInputBuilder(
       for (const msg of recentHistory) {
         let apiItemPartial: any
 
+        if (msg.role === 'system') {
+          continue
+        }
+
         if (msg.role === 'tool') {
           apiItemPartial = {
             type: 'function_call_output',
@@ -64,19 +68,6 @@ export function createApiInputBuilder(
               typeof msg.content === 'string'
                 ? msg.content
                 : JSON.stringify(msg.content),
-          }
-        } else if (msg.role === 'system') {
-          apiItemPartial = {
-            role: 'system',
-            content: [
-              {
-                type: 'input_text',
-                text:
-                  typeof msg.content === 'string'
-                    ? msg.content
-                    : JSON.stringify(msg.content),
-              },
-            ],
           }
         } else {
           const currentApiRole = msg.role as 'user' | 'assistant' | 'developer'

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -29,7 +29,7 @@ import {
   listMiniMaxModels,
 } from './llmProviders/minimax'
 import {
-  createMiniMaxChatCompletionViaMain,
+  createChatCompletionForProvider,
   stripReasoningFromMiniMaxContent,
 } from './llmProviders/openAICompatible'
 import {
@@ -730,10 +730,11 @@ export const createSummarizationResponse = async (
       ],
       stream: false,
     } as any
-    const response =
-      settings.aiProvider === 'minimax'
-        ? await createMiniMaxChatCompletionViaMain(params)
-        : await client.chat.completions.create(params)
+    const response = await createChatCompletionForProvider(
+      settings.aiProvider,
+      () => client,
+      params
+    )
 
     const content = response.choices[0]?.message?.content?.trim()
     return content ? stripReasoningFromMiniMaxContent(content) : null
@@ -787,10 +788,11 @@ export const createContextAnalysisResponse = async (
       ],
       stream: false,
     } as any
-    const response =
-      settings.aiProvider === 'minimax'
-        ? await createMiniMaxChatCompletionViaMain(params)
-        : await client.chat.completions.create(params)
+    const response = await createChatCompletionForProvider(
+      settings.aiProvider,
+      () => client,
+      params
+    )
 
     const content = response.choices[0]?.message?.content?.trim()
     return content

--- a/src/services/llmProviders/__tests__/modelDiscovery.test.ts
+++ b/src/services/llmProviders/__tests__/modelDiscovery.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { listModelsViaMainProcess } from '../modelDiscovery'
+
+describe('main-process model discovery', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete (globalThis as any).window
+  })
+
+  it('uses the Electron HTTP bridge without OpenAI SDK stainless headers', async () => {
+    const request = vi.fn().mockResolvedValue({
+      success: true,
+      status: 200,
+      data: {
+        data: [{ id: 'z-model' }, { id: 'a-model', object: 'model' }],
+      },
+    })
+    ;(globalThis as any).window = {
+      httpAPI: {
+        request,
+      },
+    }
+
+    const models = await listModelsViaMainProcess({
+      apiKey: 'sk-test',
+      baseURL: 'https://example.com/v1/',
+      providerName: 'Example',
+    })
+
+    expect(models.map(model => model.id)).toEqual(['a-model', 'z-model'])
+    expect(request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'https://example.com/v1/models',
+        method: 'GET',
+        headers: {
+          Authorization: 'Bearer sk-test',
+        },
+      })
+    )
+    expect(request.mock.calls[0][0].headers['x-stainless-os']).toBeUndefined()
+  })
+
+  it('throws HTTP status errors so provider auth handling still works', async () => {
+    ;(globalThis as any).window = {
+      httpAPI: {
+        request: vi.fn().mockResolvedValue({
+          success: true,
+          status: 401,
+          data: {
+            error: {
+              message: 'Unauthorized',
+            },
+          },
+        }),
+      },
+    }
+
+    await expect(
+      listModelsViaMainProcess({
+        apiKey: 'bad-key',
+        baseURL: 'https://example.com/v1',
+        providerName: 'Example',
+      })
+    ).rejects.toMatchObject({
+      status: 401,
+      message: 'Unauthorized',
+    })
+  })
+})

--- a/src/services/llmProviders/__tests__/openAICompatible.test.ts
+++ b/src/services/llmProviders/__tests__/openAICompatible.test.ts
@@ -22,6 +22,58 @@ function installWindowMocks() {
   }
 }
 
+function installStreamIpcMock(assertStartArgs?: (args: any) => void) {
+  const listeners = new Map<string, (event: any, payload: any) => void>()
+  const invoke = vi
+    .fn()
+    .mockImplementation(async (channel: string, args: any) => {
+      if (channel === 'http:stream-start') {
+        assertStartArgs?.(args)
+        queueMicrotask(() => {
+          const eventChannel = `http:stream:event:${args.requestId}`
+          const listener = listeners.get(eventChannel)
+          listener?.(
+            {},
+            {
+              type: 'chunk',
+              data: {
+                id: 'chatcmpl-stream-test',
+                choices: [
+                  {
+                    delta: {
+                      content: 'hello streamed',
+                    },
+                    finish_reason: 'stop',
+                  },
+                ],
+              },
+            }
+          )
+          listener?.({}, { type: 'done' })
+        })
+        return { success: true }
+      }
+      if (channel === 'http:stream-cancel') {
+        return { success: true }
+      }
+      return { success: false, error: `Unexpected channel: ${channel}` }
+    })
+
+  ;(globalThis as any).window.ipcRenderer = {
+    invoke,
+    on: vi.fn((channel: string, listener: any) => {
+      listeners.set(channel, listener)
+      return undefined
+    }),
+    off: vi.fn((channel: string) => {
+      listeners.delete(channel)
+      return undefined
+    }),
+  }
+
+  return { invoke }
+}
+
 describe('createOpenAICompatibleResponse', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
@@ -169,7 +221,7 @@ describe('createOpenAICompatibleResponse', () => {
           output: '[]',
         } as any,
       ],
-      true,
+      false,
       'Core persona instructions'
     )
 
@@ -193,5 +245,54 @@ describe('createOpenAICompatibleResponse', () => {
         '<think>The user asks whether I played it.</think>\n\nНет, я сама в неё не играла.'
       )
     ).toBe('Нет, я сама в неё не играла.')
+  })
+
+  it('streams MiniMax chat completions through the main-process bridge', async () => {
+    const settingsStore = useSettingsStore()
+    settingsStore.updateSetting('aiProvider', 'minimax')
+    settingsStore.updateSetting('VITE_MINIMAX_API_KEY', 'sk-test')
+
+    let startedStreamArgs: any = null
+    installStreamIpcMock(args => {
+      startedStreamArgs = args
+    })
+
+    const stream = await createOpenAICompatibleResponse(
+      'minimax',
+      vi.fn() as any,
+      [
+        {
+          role: 'user',
+          content: [{ type: 'input_text', text: 'hello' }],
+        } as any,
+      ],
+      true
+    )
+
+    const events: any[] = []
+    for await (const event of stream) {
+      events.push(event)
+    }
+
+    expect(startedStreamArgs).toMatchObject({
+      method: 'POST',
+      url: 'https://api.minimax.io/v1/chat/completions',
+      headers: {
+        Authorization: 'Bearer sk-test',
+        'Content-Type': 'application/json',
+      },
+      data: expect.objectContaining({
+        model: 'MiniMax-M2.7',
+        reasoning_split: true,
+        stream: true,
+      }),
+    })
+    expect(
+      events.some(
+        event =>
+          event.type === 'response.output_text.delta' &&
+          event.delta === 'hello streamed'
+      )
+    ).toBe(true)
   })
 })

--- a/src/services/llmProviders/__tests__/providerCatalog.test.ts
+++ b/src/services/llmProviders/__tests__/providerCatalog.test.ts
@@ -27,11 +27,8 @@ describe('providerCatalog', () => {
       getStaticModelsForProvider('minimax').map(model => model.id)
     ).toEqual([
       'MiniMax-M2.7',
-      'MiniMax-M2.7-highspeed',
       'MiniMax-M2.5',
-      'MiniMax-M2.5-highspeed',
       'MiniMax-M2.1',
-      'MiniMax-M2.1-highspeed',
       'MiniMax-M2',
     ])
     expect(MINIMAX_TEXT_MODELS[0]?.displayName).toBe('MiniMax M2.7')
@@ -40,7 +37,7 @@ describe('providerCatalog', () => {
   it('falls back to the MiniMax default for non-MiniMax model ids', () => {
     expect(getSafeProviderModel('minimax', 'gpt-4o-mini')).toBe('MiniMax-M2.7')
     expect(getSafeProviderModel('minimax', 'MiniMax-M2.7-highspeed')).toBe(
-      'MiniMax-M2.7-highspeed'
+      'MiniMax-M2.7'
     )
   })
 })

--- a/src/services/llmProviders/__tests__/streamAdapters.test.ts
+++ b/src/services/llmProviders/__tests__/streamAdapters.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import {
+  convertLocalLLMStreamToResponsesFormat,
+  convertOpenRouterStreamToResponsesFormat,
+} from '../streamAdapters'
+
+function createAbortError(): Error {
+  const error = new Error('The operation was aborted.')
+  error.name = 'AbortError'
+  return error
+}
+
+async function consumeStream(stream: AsyncIterable<any>): Promise<any[]> {
+  const events: any[] = []
+  for await (const event of stream) {
+    events.push(event)
+  }
+  return events
+}
+
+describe('stream adapters', () => {
+  it('preserves local provider aborts instead of converting them to server errors', async () => {
+    const abortingStream: AsyncIterable<any> = {
+      async *[Symbol.asyncIterator]() {
+        throw createAbortError()
+      },
+    }
+
+    await expect(
+      consumeStream(
+        convertLocalLLMStreamToResponsesFormat(abortingStream, 'minimax')
+      )
+    ).rejects.toMatchObject({ name: 'AbortError' })
+  })
+
+  it('preserves OpenRouter aborts instead of converting them to server errors', async () => {
+    const abortingStream: AsyncIterable<any> = {
+      async *[Symbol.asyncIterator]() {
+        throw createAbortError()
+      },
+    }
+
+    await expect(
+      consumeStream(convertOpenRouterStreamToResponsesFormat(abortingStream))
+    ).rejects.toMatchObject({ name: 'AbortError' })
+  })
+})

--- a/src/services/llmProviders/mainProcessStream.ts
+++ b/src/services/llmProviders/mainProcessStream.ts
@@ -1,0 +1,125 @@
+export interface MainProcessStreamRequest {
+  url: string
+  method?: string
+  headers?: Record<string, string>
+  params?: Record<string, any>
+  data?: any
+  timeout?: number
+}
+
+type StreamQueueEvent =
+  | { type: 'chunk'; data: any }
+  | { type: 'done' }
+  | { type: 'error'; error?: string; status?: number; data?: any }
+
+function createStreamRequestId(): string {
+  const random =
+    typeof crypto !== 'undefined' && 'randomUUID' in crypto
+      ? crypto.randomUUID()
+      : Math.random().toString(36).slice(2)
+  return `renderer-http-stream-${Date.now()}-${random}`
+}
+
+function createAbortError(): Error {
+  try {
+    return new DOMException('The operation was aborted.', 'AbortError')
+  } catch {
+    const error = new Error('The operation was aborted.')
+    error.name = 'AbortError'
+    return error
+  }
+}
+
+export async function* streamViaMainProcess(
+  request: MainProcessStreamRequest,
+  signal?: AbortSignal
+): AsyncGenerator<any> {
+  if (typeof window === 'undefined' || !window.ipcRenderer) {
+    throw new Error('Electron IPC bridge is unavailable.')
+  }
+
+  const requestId = createStreamRequestId()
+  const channel = `http:stream:event:${requestId}`
+  const queue: StreamQueueEvent[] = []
+  let pendingResolver: ((event: StreamQueueEvent) => void) | null = null
+  let finished = false
+
+  const pushEvent = (event: StreamQueueEvent) => {
+    if (finished) {
+      return
+    }
+    if (pendingResolver) {
+      const resolve = pendingResolver
+      pendingResolver = null
+      resolve(event)
+      return
+    }
+    queue.push(event)
+  }
+
+  const nextEvent = (): Promise<StreamQueueEvent> => {
+    const queued = queue.shift()
+    if (queued) {
+      return Promise.resolve(queued)
+    }
+    return new Promise(resolve => {
+      pendingResolver = resolve
+    })
+  }
+
+  const listener = (_event: any, event: StreamQueueEvent) => {
+    pushEvent(event)
+  }
+
+  const abort = () => {
+    void window.ipcRenderer.invoke('http:stream-cancel', { requestId })
+    pushEvent({ type: 'error', error: 'The operation was aborted.' })
+  }
+
+  window.ipcRenderer.on(channel, listener as any)
+  signal?.addEventListener('abort', abort, { once: true })
+
+  try {
+    if (signal?.aborted) {
+      throw createAbortError()
+    }
+
+    const startResult = await window.ipcRenderer.invoke('http:stream-start', {
+      requestId,
+      ...request,
+    })
+    if (!startResult?.success) {
+      throw new Error(startResult?.error || 'HTTP stream request failed.')
+    }
+
+    while (true) {
+      const event = await nextEvent()
+      if (event.type === 'done') {
+        break
+      }
+      if (event.type === 'error') {
+        if (signal?.aborted) {
+          throw createAbortError()
+        }
+        const message =
+          event.error ||
+          event.data?.error?.message ||
+          event.data?.message ||
+          'HTTP stream request failed.'
+        const error = new Error(message) as Error & {
+          status?: number
+          data?: any
+        }
+        error.status = event.status
+        error.data = event.data
+        throw error
+      }
+      yield event.data
+    }
+  } finally {
+    finished = true
+    signal?.removeEventListener('abort', abort)
+    window.ipcRenderer.off(channel, listener as any)
+    void window.ipcRenderer.invoke('http:stream-cancel', { requestId })
+  }
+}

--- a/src/services/llmProviders/minimax.ts
+++ b/src/services/llmProviders/minimax.ts
@@ -1,16 +1,12 @@
 import type OpenAI from 'openai'
 import { getMiniMaxClient } from '../apiClients'
 import { useSettingsStore } from '../../stores/settingsStore'
+import { createProviderModel, listModelsViaMainProcess } from './modelDiscovery'
 import { createOpenAICompatibleResponse } from './openAICompatible'
 import { MINIMAX_OPENAI_BASE_URL, MINIMAX_TEXT_MODELS } from './providerCatalog'
 
 function createMiniMaxModel(id: string): OpenAI.Models.Model {
-  return {
-    id,
-    object: 'model',
-    created: 0,
-    owned_by: 'minimax',
-  } as OpenAI.Models.Model
+  return createProviderModel(id, 'minimax')
 }
 
 function listStaticMiniMaxTextModels(): OpenAI.Models.Model[] {
@@ -19,15 +15,6 @@ function listStaticMiniMaxTextModels(): OpenAI.Models.Model[] {
 
 function isAuthError(error: any): boolean {
   return error?.status === 401 || error?.status === 403
-}
-
-function normalizeBaseUrl(baseURL: string): string {
-  return baseURL.replace(/\/+$/, '')
-}
-
-function normalizeMiniMaxModels(data: any): OpenAI.Models.Model[] {
-  const models = Array.isArray(data?.data) ? data.data : []
-  return models.filter((model: any) => typeof model?.id === 'string')
 }
 
 function filterMiniMaxTextModels(
@@ -41,33 +28,11 @@ async function fetchMiniMaxModelsViaMain(
   apiKey: string,
   baseURL: string
 ): Promise<OpenAI.Models.Model[]> {
-  if (typeof window === 'undefined' || !window.httpAPI) {
-    throw new Error('Electron HTTP bridge is unavailable.')
-  }
-
-  const response = await window.httpAPI.request({
-    url: `${normalizeBaseUrl(baseURL)}/models`,
-    method: 'GET',
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-    },
-    timeout: 10 * 1000,
+  return listModelsViaMainProcess({
+    apiKey,
+    baseURL,
+    providerName: 'MiniMax',
   })
-
-  if (!response.success) {
-    throw new Error(response.error || 'MiniMax models request failed.')
-  }
-
-  if (response.status && response.status >= 400) {
-    const error = new Error(
-      `MiniMax models request failed with status ${response.status}.`
-    ) as Error & { status?: number; data?: any }
-    error.status = response.status
-    error.data = response.data
-    throw error
-  }
-
-  return normalizeMiniMaxModels(response.data)
 }
 
 export async function listMiniMaxModelsForConfig(
@@ -89,7 +54,7 @@ export async function listMiniMaxModelsForConfig(
 export const listMiniMaxModels = async (): Promise<OpenAI.Models.Model[]> => {
   const settings = useSettingsStore().config
   return listMiniMaxModelsForConfig(
-    settings.VITE_MINIMAX_API_KEY,
+    settings.VITE_MINIMAX_API_KEY || '',
     settings.minimaxBaseUrl || MINIMAX_OPENAI_BASE_URL
   )
 }

--- a/src/services/llmProviders/modelDiscovery.ts
+++ b/src/services/llmProviders/modelDiscovery.ts
@@ -1,0 +1,85 @@
+import type OpenAI from 'openai'
+
+export interface MainProcessModelListConfig {
+  apiKey: string
+  baseURL: string
+  providerName: string
+  timeout?: number
+}
+
+export function normalizeBaseUrl(baseURL: string): string {
+  return baseURL.replace(/\/+$/, '')
+}
+
+export function createProviderModel(
+  id: string,
+  ownedBy: string
+): OpenAI.Models.Model {
+  return {
+    id,
+    object: 'model',
+    created: 0,
+    owned_by: ownedBy,
+  } as OpenAI.Models.Model
+}
+
+function normalizeModelsPayload(data: any): OpenAI.Models.Model[] {
+  const models = Array.isArray(data?.data) ? data.data : []
+  return models
+    .filter((model: any) => typeof model?.id === 'string')
+    .map((model: any) => ({
+      ...model,
+      object: model.object || 'model',
+    }))
+}
+
+export async function listModelsViaMainProcess({
+  apiKey,
+  baseURL,
+  providerName,
+  timeout = 10 * 1000,
+}: MainProcessModelListConfig): Promise<OpenAI.Models.Model[]> {
+  if (!apiKey?.trim()) {
+    throw new Error(`${providerName} API Key is not configured.`)
+  }
+  if (typeof window === 'undefined' || !window.httpAPI) {
+    throw new Error('Electron HTTP bridge is unavailable.')
+  }
+
+  const response = await window.httpAPI.request({
+    url: `${normalizeBaseUrl(baseURL)}/models`,
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+    timeout,
+  })
+
+  if (!response.success) {
+    const status = response.response?.status
+    const message =
+      response.response?.data?.error?.message ||
+      response.response?.data?.message ||
+      response.error ||
+      `${providerName} models request failed.`
+    const error = new Error(message) as Error & { status?: number; data?: any }
+    error.status = status
+    error.data = response.response?.data
+    throw error
+  }
+
+  if (response.status && response.status >= 400) {
+    const message =
+      response.data?.error?.message ||
+      response.data?.message ||
+      `${providerName} models request failed with status ${response.status}.`
+    const error = new Error(message) as Error & { status?: number; data?: any }
+    error.status = response.status
+    error.data = response.data
+    throw error
+  }
+
+  return normalizeModelsPayload(response.data).sort((a, b) =>
+    a.id.localeCompare(b.id)
+  )
+}

--- a/src/services/llmProviders/openAICompatible.ts
+++ b/src/services/llmProviders/openAICompatible.ts
@@ -1,9 +1,7 @@
 import type OpenAI from 'openai'
 import { useSettingsStore } from '../../stores/settingsStore'
-import {
-  convertChatCompletionToResponsesFormat,
-  convertLocalLLMStreamToResponsesFormat,
-} from './streamAdapters'
+import { streamViaMainProcess } from './mainProcessStream'
+import { convertLocalLLMStreamToResponsesFormat } from './streamAdapters'
 import { buildToolsForProvider } from './tools'
 import {
   MINIMAX_OPENAI_BASE_URL,
@@ -228,23 +226,21 @@ function normalizeBaseUrl(baseURL: string): string {
 }
 
 export async function createMiniMaxChatCompletionViaMain(
-  params: OpenAI.Chat.ChatCompletionCreateParams
+  params: OpenAI.Chat.ChatCompletionCreateParams,
+  signal?: AbortSignal
 ): Promise<any> {
   const settings = useSettingsStore().config
   if (!settings.VITE_MINIMAX_API_KEY?.trim()) {
     throw new Error('MiniMax API Key is not configured.')
   }
-  if (typeof window === 'undefined' || !window.httpAPI) {
-    throw new Error('Electron HTTP bridge is unavailable.')
-  }
 
   const body = {
     ...params,
-    stream: false,
+    stream: !!params.stream,
     reasoning_split: true,
   }
 
-  const response = await window.httpAPI.request({
+  const request = {
     url: `${normalizeBaseUrl(settings.minimaxBaseUrl || MINIMAX_OPENAI_BASE_URL)}/chat/completions`,
     method: 'POST',
     headers: {
@@ -253,7 +249,17 @@ export async function createMiniMaxChatCompletionViaMain(
     },
     data: body,
     timeout: 120 * 1000,
-  })
+  }
+
+  if (body.stream) {
+    return streamViaMainProcess(request, signal)
+  }
+
+  if (typeof window === 'undefined' || !window.httpAPI) {
+    throw new Error('Electron HTTP bridge is unavailable.')
+  }
+
+  const response = await window.httpAPI.request(request)
 
   if (!response.success) {
     throw new Error(response.error || 'MiniMax chat completion request failed.')
@@ -288,7 +294,7 @@ export async function createChatCompletionForProvider(
     if (signal?.aborted) {
       throw new DOMException('The operation was aborted.', 'AbortError')
     }
-    return createMiniMaxChatCompletionViaMain(params)
+    return createMiniMaxChatCompletionViaMain(params, signal)
   }
 
   return getClient().chat.completions.create(params as any, { signal })
@@ -337,7 +343,7 @@ export async function createOpenAICompatibleResponse(
       signal
     )
     return stream
-      ? convertChatCompletionToResponsesFormat(completion, provider)
+      ? convertLocalLLMStreamToResponsesFormat(completion, provider)
       : completion
   }
 

--- a/src/services/llmProviders/openAICompatible.ts
+++ b/src/services/llmProviders/openAICompatible.ts
@@ -7,6 +7,7 @@ import {
 import { buildToolsForProvider } from './tools'
 import {
   MINIMAX_OPENAI_BASE_URL,
+  type ChatCompletionsProviderKey,
   getSafeProviderModel,
 } from './providerCatalog'
 
@@ -277,6 +278,22 @@ export async function createMiniMaxChatCompletionViaMain(
   return data
 }
 
+export async function createChatCompletionForProvider(
+  provider: ChatCompletionsProviderKey,
+  getClient: OpenAIClientGetter,
+  params: OpenAI.Chat.ChatCompletionCreateParams,
+  signal?: AbortSignal
+): Promise<any> {
+  if (provider === 'minimax') {
+    if (signal?.aborted) {
+      throw new DOMException('The operation was aborted.', 'AbortError')
+    }
+    return createMiniMaxChatCompletionViaMain(params)
+  }
+
+  return getClient().chat.completions.create(params as any, { signal })
+}
+
 export async function createOpenAICompatibleResponse(
   provider: OpenAICompatibleProviderKey,
   getClient: OpenAIClientGetter,
@@ -313,23 +330,26 @@ export async function createOpenAICompatibleResponse(
   }
 
   if (provider === 'minimax') {
-    if (signal?.aborted) {
-      throw new DOMException('The operation was aborted.', 'AbortError')
-    }
-    const completion = await createMiniMaxChatCompletionViaMain(params)
+    const completion = await createChatCompletionForProvider(
+      provider,
+      getClient,
+      params,
+      signal
+    )
     return stream
       ? convertChatCompletionToResponsesFormat(completion, provider)
       : completion
   }
 
-  const client = getClient()
-
   if (stream) {
-    const chatStream = await client.chat.completions.create(params as any, {
-      signal,
-    })
+    const chatStream = await createChatCompletionForProvider(
+      provider,
+      getClient,
+      params,
+      signal
+    )
     return convertLocalLLMStreamToResponsesFormat(chatStream, provider)
   }
 
-  return client.chat.completions.create(params as any, { signal })
+  return createChatCompletionForProvider(provider, getClient, params, signal)
 }

--- a/src/services/llmProviders/openai.ts
+++ b/src/services/llmProviders/openai.ts
@@ -1,14 +1,26 @@
 import type OpenAI from 'openai'
 import { useSettingsStore } from '../../stores/settingsStore'
 import { getOpenAIClient } from '../apiClients'
+import { listModelsViaMainProcess } from './modelDiscovery'
 import { buildToolsForProvider } from './tools'
 import { buildAssistantSystemPrompt } from '../../prompts/systemPrompt'
 
-export const listOpenAIModels = async (): Promise<OpenAI.Models.Model[]> => {
-  const client = getOpenAIClient()
-  const modelsPage = await client.models.list()
+export async function listOpenAIModelsForConfig(
+  apiKey: string
+): Promise<OpenAI.Models.Model[]> {
+  const models = await listModelsViaMainProcess({
+    apiKey,
+    baseURL: 'https://api.openai.com/v1',
+    providerName: 'OpenAI',
+  })
 
-  return modelsPage.data
+  return filterOpenAIModels(models)
+}
+
+function filterOpenAIModels(
+  models: OpenAI.Models.Model[]
+): OpenAI.Models.Model[] {
+  return models
     .filter(model => {
       const id = model.id
 
@@ -34,6 +46,11 @@ export const listOpenAIModels = async (): Promise<OpenAI.Models.Model[]> => {
       return isSupportedPrefix && !isExcluded
     })
     .sort((a, b) => a.id.localeCompare(b.id))
+}
+
+export const listOpenAIModels = async (): Promise<OpenAI.Models.Model[]> => {
+  const settings = useSettingsStore().config
+  return listOpenAIModelsForConfig(settings.VITE_OPENAI_API_KEY || '')
 }
 
 export const createOpenAIResponse = async (

--- a/src/services/llmProviders/openrouter.ts
+++ b/src/services/llmProviders/openrouter.ts
@@ -1,16 +1,26 @@
 import type OpenAI from 'openai'
 import { useSettingsStore } from '../../stores/settingsStore'
 import { getOpenRouterClient } from '../apiClients'
+import { listModelsViaMainProcess } from './modelDiscovery'
 import { convertOpenRouterStreamToResponsesFormat } from './streamAdapters'
 import { buildToolsForProvider } from './tools'
 
-export const listOpenRouterModels = async (): Promise<
-  OpenAI.Models.Model[]
-> => {
-  const client = getOpenRouterClient()
-  const modelsPage = await client.models.list()
+export async function listOpenRouterModelsForConfig(
+  apiKey: string
+): Promise<OpenAI.Models.Model[]> {
+  const models = await listModelsViaMainProcess({
+    apiKey,
+    baseURL: 'https://openrouter.ai/api/v1',
+    providerName: 'OpenRouter',
+  })
 
-  return modelsPage.data
+  return filterOpenRouterModels(models)
+}
+
+function filterOpenRouterModels(
+  models: OpenAI.Models.Model[]
+): OpenAI.Models.Model[] {
+  return models
     .filter(model => {
       const id = model.id
       const isExcluded =
@@ -27,6 +37,13 @@ export const listOpenRouterModels = async (): Promise<
       return !isExcluded
     })
     .sort((a, b) => a.id.localeCompare(b.id))
+}
+
+export const listOpenRouterModels = async (): Promise<
+  OpenAI.Models.Model[]
+> => {
+  const settings = useSettingsStore().config
+  return listOpenRouterModelsForConfig(settings.VITE_OPENROUTER_API_KEY || '')
 }
 
 export const createOpenRouterResponse = async (

--- a/src/services/llmProviders/providerCatalog.ts
+++ b/src/services/llmProviders/providerCatalog.ts
@@ -28,11 +28,8 @@ export const ZAI_CODING_MODELS: ProviderModelDefinition[] = [
 
 export const MINIMAX_TEXT_MODELS: ProviderModelDefinition[] = [
   { id: 'MiniMax-M2.7', displayName: 'MiniMax M2.7' },
-  { id: 'MiniMax-M2.7-highspeed', displayName: 'MiniMax M2.7 High-Speed' },
   { id: 'MiniMax-M2.5', displayName: 'MiniMax M2.5' },
-  { id: 'MiniMax-M2.5-highspeed', displayName: 'MiniMax M2.5 High-Speed' },
   { id: 'MiniMax-M2.1', displayName: 'MiniMax M2.1' },
-  { id: 'MiniMax-M2.1-highspeed', displayName: 'MiniMax M2.1 High-Speed' },
   { id: 'MiniMax-M2', displayName: 'MiniMax M2' },
 ]
 

--- a/src/services/llmProviders/streamAdapters.ts
+++ b/src/services/llmProviders/streamAdapters.ts
@@ -1,3 +1,7 @@
+function isAbortError(error: any): boolean {
+  return error?.name === 'AbortError'
+}
+
 export async function* convertLocalLLMStreamToResponsesFormat(
   stream: any,
   provider: 'ollama' | 'lm-studio' | 'zai' | 'minimax'
@@ -186,6 +190,10 @@ export async function* convertLocalLLMStreamToResponsesFormat(
       }
     }
   } catch (error) {
+    if (isAbortError(error)) {
+      throw error
+    }
+
     console.error(`Error in ${provider} stream conversion:`, error)
 
     yield {
@@ -509,6 +517,10 @@ export async function* convertOpenRouterStreamToResponsesFormat(stream: any) {
       }
     }
   } catch (error) {
+    if (isAbortError(error)) {
+      throw error
+    }
+
     console.error('Error in OpenRouter stream conversion:', error)
 
     yield {

--- a/src/services/llmProviders/zai.ts
+++ b/src/services/llmProviders/zai.ts
@@ -1,31 +1,28 @@
 import type OpenAI from 'openai'
 import { getZAIClient } from '../apiClients'
-import {
-  createOpenAICompatibleResponse,
-  listOpenAICompatibleModels,
-} from './openAICompatible'
-import { ZAI_CODING_MODELS } from './providerCatalog'
-
-function createZAIModel(id: string): OpenAI.Models.Model {
-  return {
-    id,
-    object: 'model',
-    created: 0,
-    owned_by: 'zai',
-  } as OpenAI.Models.Model
-}
+import { createOpenAICompatibleResponse } from './openAICompatible'
+import { useSettingsStore } from '../../stores/settingsStore'
+import { createProviderModel, listModelsViaMainProcess } from './modelDiscovery'
+import { ZAI_CODING_BASE_URL, ZAI_CODING_MODELS } from './providerCatalog'
 
 function listStaticZAICodingModels(): OpenAI.Models.Model[] {
-  return ZAI_CODING_MODELS.map(model => createZAIModel(model.id))
+  return ZAI_CODING_MODELS.map(model => createProviderModel(model.id, 'zai'))
 }
 
 function isAuthError(error: any): boolean {
   return error?.status === 401 || error?.status === 403
 }
 
-export const listZAIModels = async (): Promise<OpenAI.Models.Model[]> => {
+export async function listZAIModelsForConfig(
+  apiKey: string,
+  baseURL = ZAI_CODING_BASE_URL
+): Promise<OpenAI.Models.Model[]> {
   try {
-    const models = await listOpenAICompatibleModels(getZAIClient)
+    const models = await listModelsViaMainProcess({
+      apiKey,
+      baseURL,
+      providerName: 'Z.ai',
+    })
     const codingModelIds = new Set(ZAI_CODING_MODELS.map(model => model.id))
     const codingModels = models.filter(model => codingModelIds.has(model.id))
     return codingModels.length > 0 ? codingModels : listStaticZAICodingModels()
@@ -35,6 +32,14 @@ export const listZAIModels = async (): Promise<OpenAI.Models.Model[]> => {
     }
     return listStaticZAICodingModels()
   }
+}
+
+export const listZAIModels = async (): Promise<OpenAI.Models.Model[]> => {
+  const settings = useSettingsStore().config
+  return listZAIModelsForConfig(
+    settings.VITE_ZAI_API_KEY || '',
+    settings.zaiBaseUrl || ZAI_CODING_BASE_URL
+  )
 }
 
 export const createZAIResponse = async (


### PR DESCRIPTION
## Summary
- Keep UI-only status messages in the chat UI while excluding them from inference payloads.
- Route provider chat completions through a shared adapter for assistant, summarization, and context analysis calls.
- Fetch external provider model lists through the Electron main-process HTTP bridge.
- Stream MiniMax chat completions through a main-process SSE bridge to avoid renderer CORS/header issues.

## Notes
- This keeps the existing renderer chat/tool pipeline intact while moving only the provider paths that need the main-process bridge.
- MiniMax keeps its Coding Plan-safe model handling, `reasoning_split` handling, and system-role avoidance behavior.
