### PR TITLE
Add DeepSeek provider

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,6 +1,9 @@
 #OpenAI API Key
 VITE_OPENAI_API_KEY = ''
 
+#DeepSeek API Key
+VITE_DEEPSEEK_API_KEY = ''
+
 #Groq whisper API Key
 VITE_GROQ_API_KEY = ''
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ With the local STT model, you can set a **wake-up word** (like "Hey, Siri").
 
 Fully customizable settings interface:
 
-* LLM provider selection between OpenAI, OpenRouter, Z.ai(coding plan), Minimax(token plan), Ollama, LM Studio
+* LLM provider selection between OpenAI, OpenRouter, DeepSeek, Z.ai(coding plan), Minimax(token plan), Ollama, LM Studio
 * Cloud or local TTS, STT, Embeddings
 * Model choice & parameters (temperature, top\_p, history, etc)
 * Prompt and summarization tuning
@@ -131,7 +131,7 @@ Follow the [Setup Instructions](https://github.com/pmbstyle/Alice/blob/main/docs
 * **Frontend:** [Vue.js](https://vuejs.org/), [TailwindCSS](https://tailwindcss.com/)
 * **Desktop Shell:** [Electron](https://www.electronjs.org/)
 * **State Management:** [Pinia](https://pinia.vuejs.org/)
-* **AI APIs:** [OpenAI](https://platform.openai.com/), [OpenRouter](https://openrouter.ai/), [Groq](https://console.groq.com/)
+* **AI APIs:** [OpenAI](https://platform.openai.com/), [OpenRouter](https://openrouter.ai/), [DeepSeek](https://platform.deepseek.com/), [Groq](https://console.groq.com/)
 * **Backend:** [Go](https://go.dev/)
 * **Vector search engine**: [hnswlib-node](https://github.com/nmslib/hnswlib)
 * **Local storage**: [better-sqlite3](https://github.com/WiseLibs/better-sqlite3)

--- a/docs/setupInstructions.md
+++ b/docs/setupInstructions.md
@@ -14,7 +14,7 @@ Run in your terminal `xattr -cr "/Applications/Alice AI App.app"`
 
 # AI Provider Setup
 
-Alice supports OpenAI, OpenRouter and local LLM inference.
+Alice supports OpenAI, OpenRouter, DeepSeek, MiniMax, Z.ai, and local LLM inference.
 
 ## OpenAI (Default)
 
@@ -29,6 +29,14 @@ Alice supports OpenAI, OpenRouter and local LLM inference.
 - Access to 400+ models from various providers including Claude, Llama, Gemini, and more
 - Set up either OpenAI speech to text or use built-in local voice generation
 - Models automatically include web search capabilities
+- No image generation support (use OpenAI provider for image-gen)
+
+## DeepSeek (Alternative)
+
+- Go to [DeepSeek API Platform](https://platform.deepseek.com/api_keys) to get your DeepSeek API key
+- Select "AI Provider" in Core Settings as DeepSeek
+- Use the default base URL `https://api.deepseek.com`
+- DeepSeek powers chat inference only; cloud TTS/STT/embeddings still require OpenAI or local voice and memory mode
 - No image generation support (use OpenAI provider for image-gen)
 
 ## Local Ollama / LM studio

--- a/electron/main/settingsManager.ts
+++ b/electron/main/settingsManager.ts
@@ -13,6 +13,7 @@ export interface AppSettings {
   VITE_OPENROUTER_API_KEY?: string
   VITE_ZAI_API_KEY?: string
   VITE_MINIMAX_API_KEY?: string
+  VITE_DEEPSEEK_API_KEY?: string
   VITE_GROQ_API_KEY?: string
   sttProvider?: 'openai' | 'groq' | 'transformers'
   aiProvider?:
@@ -22,6 +23,7 @@ export interface AppSettings {
     | 'lm-studio'
     | 'zai'
     | 'minimax'
+    | 'deepseek'
 
   // Transformers STT settings
   transformersModel?: string
@@ -35,6 +37,7 @@ export interface AppSettings {
   lmStudioBaseUrl?: string
   zaiBaseUrl?: string
   minimaxBaseUrl?: string
+  deepseekBaseUrl?: string
 
   assistantModel?: string
   assistantSystemPrompt?: string

--- a/src/components/settings/AssistantSettingsTab.vue
+++ b/src/components/settings/AssistantSettingsTab.vue
@@ -68,6 +68,9 @@
                 (currentSettings.aiProvider === 'minimax' &&
                   currentSettings.VITE_MINIMAX_API_KEY &&
                   currentSettings.minimaxBaseUrl) ||
+                (currentSettings.aiProvider === 'deepseek' &&
+                  currentSettings.VITE_DEEPSEEK_API_KEY &&
+                  currentSettings.deepseekBaseUrl) ||
                 (currentSettings.aiProvider === 'ollama' &&
                   currentSettings.ollamaBaseUrl) ||
                 (currentSettings.aiProvider === 'lm-studio' &&
@@ -306,6 +309,9 @@
                 (currentSettings.aiProvider === 'minimax' &&
                   currentSettings.VITE_MINIMAX_API_KEY &&
                   currentSettings.minimaxBaseUrl) ||
+                (currentSettings.aiProvider === 'deepseek' &&
+                  currentSettings.VITE_DEEPSEEK_API_KEY &&
+                  currentSettings.deepseekBaseUrl) ||
                 (currentSettings.aiProvider === 'ollama' &&
                   currentSettings.ollamaBaseUrl) ||
                 (currentSettings.aiProvider === 'lm-studio' &&
@@ -519,6 +525,7 @@ const getProviderDisplayName = (provider: string): string => {
     'lm-studio': 'LM Studio',
     zai: 'Z.ai',
     minimax: 'MiniMax',
+    deepseek: 'DeepSeek',
   }
   return providerNames[provider] || provider
 }

--- a/src/components/settings/CoreSettingsTab.vue
+++ b/src/components/settings/CoreSettingsTab.vue
@@ -21,6 +21,7 @@
             <option value="openrouter">OpenRouter</option>
             <option value="zai">Z.ai (Coding Plan)</option>
             <option value="minimax">MiniMax</option>
+            <option value="deepseek">DeepSeek</option>
             <option value="ollama">Ollama (Local)</option>
             <option value="lm-studio">LM Studio (Local)</option>
           </select>
@@ -195,6 +196,37 @@
           />
           <p class="text-xs text-gray-400 mt-1">
             OpenAI-compatible endpoint for MiniMax token/coding plans.
+          </p>
+        </div>
+        <div v-if="currentSettings.aiProvider === 'deepseek'">
+          <label for="deepseek-key" class="block mb-1 text-sm"
+            >DeepSeek API Key *</label
+          >
+          <input
+            id="deepseek-key"
+            type="password"
+            v-model="currentSettings.VITE_DEEPSEEK_API_KEY"
+            class="input focus:outline-none w-full"
+            autocomplete="new-password"
+            placeholder="sk-..."
+          />
+          <p class="text-xs text-gray-400 mt-1">
+            Required for DeepSeek chat models.
+          </p>
+        </div>
+        <div v-if="currentSettings.aiProvider === 'deepseek'">
+          <label for="deepseek-url" class="block mb-1 text-sm"
+            >DeepSeek Base URL *</label
+          >
+          <input
+            id="deepseek-url"
+            type="text"
+            v-model="currentSettings.deepseekBaseUrl"
+            class="input focus:outline-none w-full"
+            placeholder="https://api.deepseek.com"
+          />
+          <p class="text-xs text-gray-400 mt-1">
+            OpenAI-compatible endpoint for DeepSeek chat completions.
           </p>
         </div>
         <div v-if="currentSettings.aiProvider === 'lm-studio'">

--- a/src/components/wizard/OnboardingWizard.vue
+++ b/src/components/wizard/OnboardingWizard.vue
@@ -24,6 +24,7 @@
           @test-openrouter="testOpenRouterKey"
           @test-zai="testZAIKey"
           @test-minimax="testMiniMaxKey"
+          @test-deepseek="testDeepSeekKey"
           @test-ollama="testOllamaConnection"
           @test-lmstudio="testLMStudioConnection"
           @reset-tests="resetTestResults"
@@ -66,11 +67,13 @@ import VoiceModelsStep from './steps/VoiceModelsStep.vue'
 import FinalSetupStep from './steps/FinalSetupStep.vue'
 import OpenAI from 'openai'
 import {
+  DEEPSEEK_OPENAI_BASE_URL,
   MINIMAX_OPENAI_BASE_URL,
   PROVIDER_CONFIGS,
   ZAI_CODING_BASE_URL,
   type AIProviderKey,
 } from '../../services/llmProviders/providerCatalog'
+import { listDeepSeekModelsForConfig } from '../../services/llmProviders/deepseek'
 import { listMiniMaxModelsForConfig } from '../../services/llmProviders/minimax'
 import { listOpenAIModelsForConfig } from '../../services/llmProviders/openai'
 import { listOpenRouterModelsForConfig } from '../../services/llmProviders/openrouter'
@@ -111,6 +114,7 @@ const formData = reactive({
   VITE_OPENROUTER_API_KEY: '',
   VITE_ZAI_API_KEY: '',
   VITE_MINIMAX_API_KEY: '',
+  VITE_DEEPSEEK_API_KEY: '',
   aiProvider: 'openai' as AIProviderKey,
   assistantModel: openaiDefaults.assistantModel as string,
   summarizationModel: openaiDefaults.summarizationModel as string,
@@ -123,6 +127,7 @@ const formData = reactive({
   lmStudioBaseUrl: 'http://localhost:1234',
   zaiBaseUrl: ZAI_CODING_BASE_URL,
   minimaxBaseUrl: MINIMAX_OPENAI_BASE_URL,
+  deepseekBaseUrl: DEEPSEEK_OPENAI_BASE_URL,
   useLocalModels: false,
   availableModels: [] as string[],
   localSttLanguage: 'auto',
@@ -133,6 +138,7 @@ const isTesting = reactive({
   openrouter: false,
   zai: false,
   minimax: false,
+  deepseek: false,
   ollama: false,
   lmStudio: false,
 })
@@ -142,6 +148,7 @@ const testResult = reactive({
   openrouter: { success: false, error: '' },
   zai: { success: false, error: '' },
   minimax: { success: false, error: '' },
+  deepseek: { success: false, error: '' },
   ollama: { success: false, error: '' },
   lmStudio: { success: false, error: '' },
 })
@@ -173,7 +180,8 @@ const canContinue = computed(() => {
           formData.aiProvider === 'lm-studio' ||
           formData.aiProvider === 'openrouter' ||
           formData.aiProvider === 'zai' ||
-          formData.aiProvider === 'minimax') &&
+          formData.aiProvider === 'minimax' ||
+          formData.aiProvider === 'deepseek') &&
         !formData.VITE_OPENAI_API_KEY.trim()
       ) {
         return false
@@ -245,6 +253,8 @@ const fetchAvailableModels = async () => {
       baseURL = formData.zaiBaseUrl
     } else if (formData.aiProvider === 'minimax') {
       baseURL = formData.minimaxBaseUrl
+    } else if (formData.aiProvider === 'deepseek') {
+      baseURL = formData.deepseekBaseUrl
     } else {
       return
     }
@@ -252,6 +262,20 @@ const fetchAvailableModels = async () => {
     if (formData.aiProvider === 'minimax') {
       const models = await listMiniMaxModelsForConfig(
         formData.VITE_MINIMAX_API_KEY,
+        baseURL
+      )
+      formData.availableModels = models.map(model => model.id)
+
+      if (formData.availableModels.length > 0) {
+        formData.assistantModel = formData.availableModels[0]
+        formData.summarizationModel = formData.availableModels[0]
+      }
+      return
+    }
+
+    if (formData.aiProvider === 'deepseek') {
+      const models = await listDeepSeekModelsForConfig(
+        formData.VITE_DEEPSEEK_API_KEY,
         baseURL
       )
       formData.availableModels = models.map(model => model.id)
@@ -414,6 +438,39 @@ const testMiniMaxKey = async () => {
   }
 }
 
+const testDeepSeekKey = async () => {
+  if (!formData.VITE_DEEPSEEK_API_KEY.trim()) {
+    testResult.deepseek.error = 'API Key cannot be empty.'
+    testResult.deepseek.success = false
+    return
+  }
+  if (!formData.deepseekBaseUrl.trim()) {
+    testResult.deepseek.error = 'Base URL cannot be empty.'
+    testResult.deepseek.success = false
+    return
+  }
+
+  isTesting.deepseek = true
+  testResult.deepseek.error = ''
+  testResult.deepseek.success = false
+
+  try {
+    await fetchAvailableModels()
+    testResult.deepseek.success = true
+  } catch (e: any) {
+    testResult.deepseek.error =
+      'API key or OpenAI-compatible endpoint is invalid or has no permissions.'
+    if (e.message?.includes('401')) {
+      testResult.deepseek.error = 'Invalid API key - please check your key.'
+    } else if (e.message?.includes('429')) {
+      testResult.deepseek.error =
+        'Rate limit exceeded - please try again later.'
+    }
+  } finally {
+    isTesting.deepseek = false
+  }
+}
+
 const testOllamaConnection = async () => {
   if (!formData.ollamaBaseUrl.trim()) {
     testResult.ollama.error = 'Ollama Base URL cannot be empty.'
@@ -499,6 +556,8 @@ const resetTestResults = () => {
   testResult.zai.error = ''
   testResult.minimax.success = false
   testResult.minimax.error = ''
+  testResult.deepseek.success = false
+  testResult.deepseek.error = ''
   testResult.ollama.success = false
   testResult.ollama.error = ''
   testResult.lmStudio.success = false
@@ -519,6 +578,12 @@ const isCurrentProviderTested = () => {
   } else if (formData.aiProvider === 'minimax') {
     return (
       testResult.minimax.success &&
+      Boolean(formData.assistantModel) &&
+      Boolean(formData.summarizationModel)
+    )
+  } else if (formData.aiProvider === 'deepseek') {
+    return (
+      testResult.deepseek.success &&
       Boolean(formData.assistantModel) &&
       Boolean(formData.summarizationModel)
     )

--- a/src/components/wizard/steps/AIProviderStep.vue
+++ b/src/components/wizard/steps/AIProviderStep.vue
@@ -23,6 +23,7 @@
         </option>
         <option value="zai">Z.ai (GLM Coding Plan)</option>
         <option value="minimax">MiniMax (OpenAI-compatible)</option>
+        <option value="deepseek">DeepSeek (OpenAI-compatible)</option>
         <option value="ollama">Ollama (Local LLMs)</option>
         <option value="lm-studio">LM Studio (Local LLMs)</option>
       </select>
@@ -386,6 +387,122 @@
       </div>
     </div>
 
+    <!-- DeepSeek Configuration -->
+    <div v-else-if="formData.aiProvider === 'deepseek'" class="space-y-4">
+      <div class="alert alert-info text-sm">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          class="stroke-current shrink-0 w-5 h-5"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+          ></path>
+        </svg>
+        <span>
+          DeepSeek uses an OpenAI-compatible chat completions endpoint. Alice
+          disables DeepSeek thinking mode for tool-call compatibility.
+        </span>
+      </div>
+
+      <div class="form-control">
+        <label class="label">
+          <span class="label-text">DeepSeek API Key</span>
+        </label>
+        <input
+          type="password"
+          v-model="formData.VITE_DEEPSEEK_API_KEY"
+          placeholder="sk-..."
+          class="input input-bordered w-full focus:input-primary"
+          :class="{
+            'input-error':
+              testResult.deepseek.error && !testResult.deepseek.success,
+          }"
+        />
+      </div>
+
+      <div class="form-control">
+        <label class="label">
+          <span class="label-text">DeepSeek Base URL</span>
+        </label>
+        <input
+          type="text"
+          v-model="formData.deepseekBaseUrl"
+          placeholder="https://api.deepseek.com"
+          class="input input-bordered w-full focus:input-primary"
+          :class="{
+            'input-error':
+              testResult.deepseek.error && !testResult.deepseek.success,
+          }"
+        />
+      </div>
+
+      <button
+        @click="$emit('test-deepseek')"
+        class="btn btn-secondary w-full"
+        :disabled="
+          isTesting.deepseek ||
+          !formData.VITE_DEEPSEEK_API_KEY.trim() ||
+          !formData.deepseekBaseUrl.trim()
+        "
+      >
+        <span
+          v-if="isTesting.deepseek"
+          class="loading loading-spinner loading-xs mr-2"
+        ></span>
+        Test DeepSeek Key
+      </button>
+
+      <TestResult :result="testResult.deepseek" />
+
+      <div
+        v-if="
+          testResult.deepseek.success && formData.availableModels.length > 0
+        "
+        class="space-y-4"
+      >
+        <div class="form-control">
+          <label class="label">
+            <span class="label-text">Assistant Model</span>
+          </label>
+          <select
+            v-model="formData.assistantModel"
+            class="select select-bordered w-full focus:select-primary focus:outline-none"
+          >
+            <option
+              v-for="model in formData.availableModels"
+              :key="model"
+              :value="model"
+            >
+              {{ model }}
+            </option>
+          </select>
+        </div>
+
+        <div class="form-control">
+          <label class="label">
+            <span class="label-text">Summarization Model</span>
+          </label>
+          <select
+            v-model="formData.summarizationModel"
+            class="select select-bordered w-full focus:select-primary focus:outline-none"
+          >
+            <option
+              v-for="model in formData.availableModels"
+              :key="model"
+              :value="model"
+            >
+              {{ model }}
+            </option>
+          </select>
+        </div>
+      </div>
+    </div>
+
     <!-- Ollama Configuration -->
     <div v-else-if="formData.aiProvider === 'ollama'" class="space-y-4">
       <div class="alert alert-info text-sm">
@@ -594,6 +711,7 @@ defineEmits<{
   'test-openrouter': []
   'test-zai': []
   'test-minimax': []
+  'test-deepseek': []
   'test-ollama': []
   'test-lmstudio': []
   'reset-tests': []

--- a/src/components/wizard/steps/FinalSetupStep.vue
+++ b/src/components/wizard/steps/FinalSetupStep.vue
@@ -158,6 +158,7 @@ const providerLabel = (provider: string) => {
     'lm-studio': 'LM Studio',
     local: 'Local',
     minimax: 'MiniMax',
+    deepseek: 'DeepSeek',
     ollama: 'Ollama',
     openai: 'OpenAI',
     openrouter: 'OpenRouter',

--- a/src/components/wizard/steps/VoiceModelsStep.vue
+++ b/src/components/wizard/steps/VoiceModelsStep.vue
@@ -155,7 +155,8 @@
               formData.aiProvider === 'lm-studio' ||
               formData.aiProvider === 'openrouter' ||
               formData.aiProvider === 'zai' ||
-              formData.aiProvider === 'minimax') &&
+              formData.aiProvider === 'minimax' ||
+              formData.aiProvider === 'deepseek') &&
             !formData.VITE_OPENAI_API_KEY?.trim()
           "
           class="alert alert-warning text-sm"
@@ -206,7 +207,8 @@
             formData.aiProvider === 'lm-studio' ||
             formData.aiProvider === 'openrouter' ||
             formData.aiProvider === 'zai' ||
-            formData.aiProvider === 'minimax'
+            formData.aiProvider === 'minimax' ||
+            formData.aiProvider === 'deepseek'
           "
           class="form-control"
         >

--- a/src/modules/conversation/backendService.ts
+++ b/src/modules/conversation/backendService.ts
@@ -9,10 +9,12 @@ export interface BackendServiceDependencies {
     VITE_OPENROUTER_API_KEY?: string
     VITE_ZAI_API_KEY?: string
     VITE_MINIMAX_API_KEY?: string
+    VITE_DEEPSEEK_API_KEY?: string
     ollamaBaseUrl?: string
     lmStudioBaseUrl?: string
     zaiBaseUrl?: string
     minimaxBaseUrl?: string
+    deepseekBaseUrl?: string
   }
   setStatusMessage(message: string): void
   fetchOpenAIModels(): Promise<any[]>
@@ -92,6 +94,14 @@ export function createBackendService(
       deps.logInfo('Cannot fetch models: MiniMax Base URL is missing.')
       return
     }
+    if (provider === 'deepseek' && !config.VITE_DEEPSEEK_API_KEY) {
+      deps.logInfo('Cannot fetch models: DeepSeek API Key is missing.')
+      return
+    }
+    if (provider === 'deepseek' && !config.deepseekBaseUrl) {
+      deps.logInfo('Cannot fetch models: DeepSeek Base URL is missing.')
+      return
+    }
     if (provider === 'ollama' && !config.ollamaBaseUrl) {
       deps.logInfo('Cannot fetch models: Ollama Base URL is missing.')
       return
@@ -112,6 +122,7 @@ export function createBackendService(
         'lm-studio': 'LM Studio',
         zai: 'Z.ai',
         minimax: 'MiniMax',
+        deepseek: 'DeepSeek',
       }
       const providerName = providerNameMap[provider] || provider
       deps.setStatusMessage(`Error: Could not fetch ${providerName} models.`)

--- a/src/services/apiClients.ts
+++ b/src/services/apiClients.ts
@@ -3,6 +3,7 @@ import Groq from 'groq-sdk'
 import { useSettingsStore } from '../stores/settingsStore'
 import { backendApi } from './backendApi'
 import {
+  DEEPSEEK_OPENAI_BASE_URL,
   MINIMAX_OPENAI_BASE_URL,
   ZAI_CODING_BASE_URL,
 } from './llmProviders/providerCatalog'
@@ -14,6 +15,7 @@ let ollamaClient: OpenAI | null = null
 let lmStudioClient: OpenAI | null = null
 let zaiClient: OpenAI | null = null
 let minimaxClient: OpenAI | null = null
+let deepseekClient: OpenAI | null = null
 
 export function getOpenAIClient(): OpenAI {
   if (!openaiClient) {
@@ -83,6 +85,16 @@ export function getMiniMaxClient(): OpenAI {
     throw new Error('MiniMax client could not be initialized')
   }
   return minimaxClient
+}
+
+export function getDeepSeekClient(): OpenAI {
+  if (!deepseekClient) {
+    initializeDeepSeekClient()
+  }
+  if (!deepseekClient) {
+    throw new Error('DeepSeek client could not be initialized')
+  }
+  return deepseekClient
 }
 
 function initializeOpenAIClient(): void {
@@ -198,6 +210,22 @@ function initializeMiniMaxClient(): void {
   })
 }
 
+function initializeDeepSeekClient(): void {
+  const settings = useSettingsStore().config
+  if (!settings.VITE_DEEPSEEK_API_KEY) {
+    console.error('DeepSeek API Key is not configured.')
+    throw new Error('DeepSeek API Key is not configured.')
+  }
+
+  deepseekClient = new OpenAI({
+    apiKey: settings.VITE_DEEPSEEK_API_KEY,
+    baseURL: settings.deepseekBaseUrl || DEEPSEEK_OPENAI_BASE_URL,
+    dangerouslyAllowBrowser: true,
+    timeout: 20 * 1000,
+    maxRetries: 1,
+  })
+}
+
 export function reinitializeClients(): void {
   console.log('Reinitializing API clients with updated settings...')
 
@@ -255,6 +283,14 @@ export function reinitializeClients(): void {
   } catch (error) {
     console.error('Failed to reinitialize MiniMax client:', error)
     minimaxClient = null
+  }
+
+  try {
+    initializeDeepSeekClient()
+    console.log('DeepSeek client reinitialized successfully')
+  } catch (error) {
+    console.error('Failed to reinitialize DeepSeek client:', error)
+    deepseekClient = null
   }
 }
 

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -9,6 +9,7 @@ import {
   getLMStudioClient,
   getZAIClient,
   getMiniMaxClient,
+  getDeepSeekClient,
 } from './apiClients'
 import {
   createOpenAIResponse as createOpenAIResponseWithOpenAI,
@@ -28,6 +29,10 @@ import {
   createMiniMaxResponse,
   listMiniMaxModels,
 } from './llmProviders/minimax'
+import {
+  createDeepSeekResponse,
+  listDeepSeekModels,
+} from './llmProviders/deepseek'
 import {
   createChatCompletionForProvider,
   stripReasoningFromMiniMaxContent,
@@ -108,6 +113,8 @@ function getAIClient(): OpenAI {
       return getZAIClient()
     case 'minimax':
       return getMiniMaxClient()
+    case 'deepseek':
+      return getDeepSeekClient()
     default:
       return getOpenAIClient()
   }
@@ -129,6 +136,9 @@ export const fetchOpenAIModels = async (): Promise<OpenAI.Models.Model[]> => {
   }
   if (settings.aiProvider === 'minimax') {
     return listMiniMaxModels()
+  }
+  if (settings.aiProvider === 'deepseek') {
+    return listDeepSeekModels()
   }
   return listOpenAIModels()
 }
@@ -180,6 +190,15 @@ export const createOpenAIResponse = async (
   }
   if (settings.aiProvider === 'minimax') {
     return createMiniMaxResponse(
+      input,
+      previousResponseId,
+      stream,
+      customInstructions,
+      signal
+    )
+  }
+  if (settings.aiProvider === 'deepseek') {
+    return createDeepSeekResponse(
       input,
       previousResponseId,
       stream,

--- a/src/services/llmProviders/__tests__/deepseek.test.ts
+++ b/src/services/llmProviders/__tests__/deepseek.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { listDeepSeekModelsForConfig } from '../deepseek'
+
+describe('DeepSeek model listing', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete (globalThis as any).window
+  })
+
+  it('uses the Electron HTTP bridge and filters to supported text models', async () => {
+    const request = vi.fn().mockResolvedValue({
+      success: true,
+      status: 200,
+      data: {
+        data: [
+          { id: 'deepseek-v4-flash' },
+          { id: 'deepseek-v4-pro' },
+          { id: 'unrelated-model' },
+        ],
+      },
+    })
+    ;(globalThis as any).window = {
+      httpAPI: {
+        request,
+      },
+    }
+
+    const models = await listDeepSeekModelsForConfig(
+      'sk-test',
+      'https://api.deepseek.com/'
+    )
+
+    expect(models.map(model => model.id)).toEqual([
+      'deepseek-v4-flash',
+      'deepseek-v4-pro',
+    ])
+    expect(request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'https://api.deepseek.com/models',
+        method: 'GET',
+        headers: {
+          Authorization: 'Bearer sk-test',
+        },
+      })
+    )
+    expect(request.mock.calls[0][0].headers['x-stainless-os']).toBeUndefined()
+  })
+})

--- a/src/services/llmProviders/__tests__/openAICompatible.test.ts
+++ b/src/services/llmProviders/__tests__/openAICompatible.test.ts
@@ -175,6 +175,41 @@ describe('createOpenAICompatibleResponse', () => {
     expect(request.mock.calls[0][0].headers['x-stainless-os']).toBeUndefined()
   })
 
+  it('sends DeepSeek chat completions with thinking disabled', async () => {
+    const settingsStore = useSettingsStore()
+    settingsStore.updateSetting('aiProvider', 'deepseek')
+    settingsStore.updateSetting('assistantModel', 'deepseek-chat')
+
+    const create = vi.fn().mockResolvedValue({ choices: [] })
+    const client = {
+      chat: {
+        completions: {
+          create,
+        },
+      },
+    }
+
+    await createOpenAICompatibleResponse(
+      'deepseek',
+      () => client as any,
+      [
+        {
+          role: 'user',
+          content: [{ type: 'input_text', text: 'hello' }],
+        } as any,
+      ],
+      false
+    )
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'deepseek-v4-flash',
+        thinking: { type: 'disabled' },
+      }),
+      expect.any(Object)
+    )
+  })
+
   it('does not send system-role messages to MiniMax continuations', async () => {
     const settingsStore = useSettingsStore()
     settingsStore.updateSetting('aiProvider', 'minimax')

--- a/src/services/llmProviders/__tests__/providerCatalog.test.ts
+++ b/src/services/llmProviders/__tests__/providerCatalog.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  DEEPSEEK_TEXT_MODELS,
   MINIMAX_TEXT_MODELS,
   ZAI_CODING_MODELS,
   getSafeProviderModel,
@@ -25,12 +26,7 @@ describe('providerCatalog', () => {
   it('exposes MiniMax text models with API model ids', () => {
     expect(
       getStaticModelsForProvider('minimax').map(model => model.id)
-    ).toEqual([
-      'MiniMax-M2.7',
-      'MiniMax-M2.5',
-      'MiniMax-M2.1',
-      'MiniMax-M2',
-    ])
+    ).toEqual(['MiniMax-M2.7', 'MiniMax-M2.5', 'MiniMax-M2.1', 'MiniMax-M2'])
     expect(MINIMAX_TEXT_MODELS[0]?.displayName).toBe('MiniMax M2.7')
   })
 
@@ -38,6 +34,22 @@ describe('providerCatalog', () => {
     expect(getSafeProviderModel('minimax', 'gpt-4o-mini')).toBe('MiniMax-M2.7')
     expect(getSafeProviderModel('minimax', 'MiniMax-M2.7-highspeed')).toBe(
       'MiniMax-M2.7'
+    )
+  })
+
+  it('exposes DeepSeek text models with current API model ids', () => {
+    expect(
+      getStaticModelsForProvider('deepseek').map(model => model.id)
+    ).toEqual(['deepseek-v4-flash', 'deepseek-v4-pro'])
+    expect(DEEPSEEK_TEXT_MODELS[0]?.displayName).toBe('DeepSeek V4 Flash')
+  })
+
+  it('falls back to the DeepSeek default for old model aliases', () => {
+    expect(getSafeProviderModel('deepseek', 'deepseek-chat')).toBe(
+      'deepseek-v4-flash'
+    )
+    expect(getSafeProviderModel('deepseek', 'deepseek-v4-pro')).toBe(
+      'deepseek-v4-pro'
     )
   })
 })

--- a/src/services/llmProviders/deepseek.ts
+++ b/src/services/llmProviders/deepseek.ts
@@ -1,0 +1,73 @@
+import type OpenAI from 'openai'
+import { getDeepSeekClient } from '../apiClients'
+import { useSettingsStore } from '../../stores/settingsStore'
+import { createProviderModel, listModelsViaMainProcess } from './modelDiscovery'
+import { createOpenAICompatibleResponse } from './openAICompatible'
+import {
+  DEEPSEEK_OPENAI_BASE_URL,
+  DEEPSEEK_TEXT_MODELS,
+} from './providerCatalog'
+
+function createDeepSeekModel(id: string): OpenAI.Models.Model {
+  return createProviderModel(id, 'deepseek')
+}
+
+function listStaticDeepSeekTextModels(): OpenAI.Models.Model[] {
+  return DEEPSEEK_TEXT_MODELS.map(model => createDeepSeekModel(model.id))
+}
+
+function isAuthError(error: any): boolean {
+  return error?.status === 401 || error?.status === 403
+}
+
+function filterDeepSeekTextModels(
+  models: OpenAI.Models.Model[]
+): OpenAI.Models.Model[] {
+  const textModelIds = new Set(DEEPSEEK_TEXT_MODELS.map(model => model.id))
+  return models.filter(model => textModelIds.has(model.id))
+}
+
+export async function listDeepSeekModelsForConfig(
+  apiKey: string,
+  baseURL = DEEPSEEK_OPENAI_BASE_URL
+): Promise<OpenAI.Models.Model[]> {
+  try {
+    const models = await listModelsViaMainProcess({
+      apiKey,
+      baseURL,
+      providerName: 'DeepSeek',
+    })
+    const textModels = filterDeepSeekTextModels(models)
+    return textModels.length > 0 ? textModels : listStaticDeepSeekTextModels()
+  } catch (error) {
+    if (isAuthError(error)) {
+      throw error
+    }
+    return listStaticDeepSeekTextModels()
+  }
+}
+
+export const listDeepSeekModels = async (): Promise<OpenAI.Models.Model[]> => {
+  const settings = useSettingsStore().config
+  return listDeepSeekModelsForConfig(
+    settings.VITE_DEEPSEEK_API_KEY || '',
+    settings.deepseekBaseUrl || DEEPSEEK_OPENAI_BASE_URL
+  )
+}
+
+export const createDeepSeekResponse = async (
+  input: OpenAI.Responses.Request.InputItemLike[],
+  _previousResponseId: string | null,
+  stream: boolean = false,
+  customInstructions?: string,
+  signal?: AbortSignal
+): Promise<any> => {
+  return createOpenAICompatibleResponse(
+    'deepseek',
+    getDeepSeekClient,
+    input,
+    stream,
+    customInstructions,
+    signal
+  )
+}

--- a/src/services/llmProviders/openAICompatible.ts
+++ b/src/services/llmProviders/openAICompatible.ts
@@ -10,7 +10,7 @@ import {
 } from './providerCatalog'
 
 type OpenAIClientGetter = () => OpenAI
-type OpenAICompatibleProviderKey = 'zai' | 'minimax'
+type OpenAICompatibleProviderKey = 'zai' | 'minimax' | 'deepseek'
 
 function convertResponsesInputToChatMessages(
   input: OpenAI.Responses.Request.InputItemLike[]
@@ -333,6 +333,10 @@ export async function createOpenAICompatibleResponse(
       : {}),
     tools: convertToolsForChatCompletions(finalToolsForApi),
     stream,
+  }
+
+  if (provider === 'deepseek') {
+    ;(params as any).thinking = { type: 'disabled' }
   }
 
   if (provider === 'minimax') {

--- a/src/services/llmProviders/providerCatalog.ts
+++ b/src/services/llmProviders/providerCatalog.ts
@@ -5,6 +5,7 @@ export type AIProviderKey =
   | 'lm-studio'
   | 'zai'
   | 'minimax'
+  | 'deepseek'
 
 export type ChatCompletionsProviderKey = Exclude<AIProviderKey, 'openai'>
 
@@ -31,6 +32,11 @@ export const MINIMAX_TEXT_MODELS: ProviderModelDefinition[] = [
   { id: 'MiniMax-M2.5', displayName: 'MiniMax M2.5' },
   { id: 'MiniMax-M2.1', displayName: 'MiniMax M2.1' },
   { id: 'MiniMax-M2', displayName: 'MiniMax M2' },
+]
+
+export const DEEPSEEK_TEXT_MODELS: ProviderModelDefinition[] = [
+  { id: 'deepseek-v4-flash', displayName: 'DeepSeek V4 Flash' },
+  { id: 'deepseek-v4-pro', displayName: 'DeepSeek V4 Pro' },
 ]
 
 export const PROVIDER_CONFIGS: Record<AIProviderKey, ProviderConfig> = {
@@ -64,10 +70,16 @@ export const PROVIDER_CONFIGS: Record<AIProviderKey, ProviderConfig> = {
     defaultModel: 'MiniMax-M2.7',
     nativeWebSearch: false,
   },
+  deepseek: {
+    displayName: 'DeepSeek',
+    defaultModel: 'deepseek-v4-flash',
+    nativeWebSearch: false,
+  },
 }
 
 export const ZAI_CODING_BASE_URL = 'https://api.z.ai/api/coding/paas/v4'
 export const MINIMAX_OPENAI_BASE_URL = 'https://api.minimax.io/v1'
+export const DEEPSEEK_OPENAI_BASE_URL = 'https://api.deepseek.com'
 
 export const CHAT_COMPLETIONS_PROVIDERS: ChatCompletionsProviderKey[] = [
   'openrouter',
@@ -75,6 +87,7 @@ export const CHAT_COMPLETIONS_PROVIDERS: ChatCompletionsProviderKey[] = [
   'lm-studio',
   'zai',
   'minimax',
+  'deepseek',
 ]
 
 export function getProviderDisplayName(provider: string): string {
@@ -89,6 +102,9 @@ export function getStaticModelsForProvider(
   }
   if (provider === 'minimax') {
     return MINIMAX_TEXT_MODELS
+  }
+  if (provider === 'deepseek') {
+    return DEEPSEEK_TEXT_MODELS
   }
   return []
 }

--- a/src/services/llmProviders/streamAdapters.ts
+++ b/src/services/llmProviders/streamAdapters.ts
@@ -4,7 +4,7 @@ function isAbortError(error: any): boolean {
 
 export async function* convertLocalLLMStreamToResponsesFormat(
   stream: any,
-  provider: 'ollama' | 'lm-studio' | 'zai' | 'minimax'
+  provider: 'ollama' | 'lm-studio' | 'zai' | 'minimax' | 'deepseek'
 ) {
   let responseId = `${provider}-${Date.now()}`
   let messageItemId = `message-${Date.now()}`
@@ -208,7 +208,7 @@ export async function* convertLocalLLMStreamToResponsesFormat(
 
 export async function* convertChatCompletionToResponsesFormat(
   completion: any,
-  provider: 'zai' | 'minimax'
+  provider: 'zai' | 'minimax' | 'deepseek'
 ) {
   const responseId = completion?.id || `${provider}-${Date.now()}`
   const messageItemId = `message-${Date.now()}`

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -5,6 +5,7 @@ import { useGeneralStore } from './generalStore'
 import { reinitializeClients } from '../services/apiClients'
 import { DEFAULT_PERSONA_PROMPT } from '../prompts/defaultPersonaPrompt'
 import {
+  DEEPSEEK_OPENAI_BASE_URL,
   MINIMAX_OPENAI_BASE_URL,
   PROVIDER_CONFIGS,
   ZAI_CODING_BASE_URL,
@@ -32,6 +33,7 @@ export interface AliceSettings {
   VITE_OPENROUTER_API_KEY: string
   VITE_ZAI_API_KEY: string
   VITE_MINIMAX_API_KEY: string
+  VITE_DEEPSEEK_API_KEY: string
   VITE_GROQ_API_KEY: string
   VITE_GOOGLE_API_KEY: string
   sttProvider: 'openai' | 'groq' | 'google' | 'local'
@@ -47,6 +49,7 @@ export interface AliceSettings {
   lmStudioBaseUrl: string
   zaiBaseUrl: string
   minimaxBaseUrl: string
+  deepseekBaseUrl: string
 
   assistantModel: string
   assistantSystemPrompt: string
@@ -105,6 +108,9 @@ function hasMinimumConfigForOnboarding(config: AliceSettings): boolean {
   if (config.VITE_MINIMAX_API_KEY?.trim()) {
     return true
   }
+  if (config.VITE_DEEPSEEK_API_KEY?.trim()) {
+    return true
+  }
 
   if (config.aiProvider === 'ollama') {
     return Boolean(config.ollamaBaseUrl?.trim())
@@ -121,6 +127,7 @@ const defaultSettings: AliceSettings = {
   VITE_OPENROUTER_API_KEY: '',
   VITE_ZAI_API_KEY: '',
   VITE_MINIMAX_API_KEY: '',
+  VITE_DEEPSEEK_API_KEY: '',
   VITE_GROQ_API_KEY: '',
   VITE_GOOGLE_API_KEY: '',
   sttProvider: 'openai',
@@ -135,6 +142,7 @@ const defaultSettings: AliceSettings = {
   lmStudioBaseUrl: 'http://localhost:1234',
   zaiBaseUrl: ZAI_CODING_BASE_URL,
   minimaxBaseUrl: MINIMAX_OPENAI_BASE_URL,
+  deepseekBaseUrl: DEEPSEEK_OPENAI_BASE_URL,
 
   assistantModel: 'gpt-4.1-mini',
   assistantSystemPrompt: DEFAULT_PERSONA_PROMPT,
@@ -191,6 +199,7 @@ const settingKeyToLabelMap: Record<keyof AliceSettings, string> = {
   VITE_OPENROUTER_API_KEY: 'OpenRouter API Key',
   VITE_ZAI_API_KEY: 'Z.ai API Key',
   VITE_MINIMAX_API_KEY: 'MiniMax API Key',
+  VITE_DEEPSEEK_API_KEY: 'DeepSeek API Key',
   VITE_GROQ_API_KEY: 'Groq API Key (STT)',
   VITE_GOOGLE_API_KEY: 'Google API Key',
   sttProvider: 'Speech-to-Text Provider',
@@ -206,6 +215,7 @@ const settingKeyToLabelMap: Record<keyof AliceSettings, string> = {
   lmStudioBaseUrl: 'LM Studio Base URL',
   zaiBaseUrl: 'Z.ai Base URL',
   minimaxBaseUrl: 'MiniMax Base URL',
+  deepseekBaseUrl: 'DeepSeek Base URL',
 
   assistantModel: 'Assistant Model',
   assistantSystemPrompt: 'Assistant Persona Prompt',
@@ -254,6 +264,7 @@ const ESSENTIAL_CORE_API_KEYS: (keyof AliceSettings)[] = [
   'VITE_OPENROUTER_API_KEY',
   'VITE_ZAI_API_KEY',
   'VITE_MINIMAX_API_KEY',
+  'VITE_DEEPSEEK_API_KEY',
 ]
 
 function requiresOpenAIKey(config: AliceSettings): boolean {
@@ -327,6 +338,7 @@ export const useSettingsStore = defineStore('settings', () => {
       'lm-studio',
       'zai',
       'minimax',
+      'deepseek',
     ] as const
     if (!validAIProviders.includes(validated.aiProvider as any)) {
       validated.aiProvider = 'openai'
@@ -411,6 +423,8 @@ export const useSettingsStore = defineStore('settings', () => {
       essentialKeys.push('VITE_ZAI_API_KEY', 'zaiBaseUrl')
     } else if (settings.value.aiProvider === 'minimax') {
       essentialKeys.push('VITE_MINIMAX_API_KEY', 'minimaxBaseUrl')
+    } else if (settings.value.aiProvider === 'deepseek') {
+      essentialKeys.push('VITE_DEEPSEEK_API_KEY', 'deepseekBaseUrl')
     } else if (settings.value.aiProvider === 'ollama') {
       essentialKeys.push('ollamaBaseUrl')
     } else if (settings.value.aiProvider === 'lm-studio') {
@@ -469,6 +483,13 @@ export const useSettingsStore = defineStore('settings', () => {
       return (
         !!settings.value.VITE_MINIMAX_API_KEY?.trim() &&
         !!settings.value.minimaxBaseUrl?.trim()
+      )
+    }
+
+    if (settings.value.aiProvider === 'deepseek') {
+      return (
+        !!settings.value.VITE_DEEPSEEK_API_KEY?.trim() &&
+        !!settings.value.deepseekBaseUrl?.trim()
       )
     }
 
@@ -717,6 +738,10 @@ export const useSettingsStore = defineStore('settings', () => {
         settings.value.assistantModel = PROVIDER_CONFIGS.minimax.defaultModel
         settings.value.SUMMARIZATION_MODEL =
           PROVIDER_CONFIGS.minimax.defaultModel
+      } else if (settings.value.aiProvider === 'deepseek') {
+        settings.value.assistantModel = PROVIDER_CONFIGS.deepseek.defaultModel
+        settings.value.SUMMARIZATION_MODEL =
+          PROVIDER_CONFIGS.deepseek.defaultModel
       }
     }
     if (key === 'assistantReasoningEffort') {
@@ -757,10 +782,12 @@ export const useSettingsStore = defineStore('settings', () => {
       key === 'VITE_OPENROUTER_API_KEY' ||
       key === 'VITE_ZAI_API_KEY' ||
       key === 'VITE_MINIMAX_API_KEY' ||
+      key === 'VITE_DEEPSEEK_API_KEY' ||
       key === 'ollamaBaseUrl' ||
       key === 'lmStudioBaseUrl' ||
       key === 'zaiBaseUrl' ||
       key === 'minimaxBaseUrl' ||
+      key === 'deepseekBaseUrl' ||
       key === 'aiProvider'
     ) {
       coreOpenAISettingsValid.value = false
@@ -799,6 +826,7 @@ export const useSettingsStore = defineStore('settings', () => {
         VITE_OPENROUTER_API_KEY: settings.value.VITE_OPENROUTER_API_KEY,
         VITE_ZAI_API_KEY: settings.value.VITE_ZAI_API_KEY,
         VITE_MINIMAX_API_KEY: settings.value.VITE_MINIMAX_API_KEY,
+        VITE_DEEPSEEK_API_KEY: settings.value.VITE_DEEPSEEK_API_KEY,
         VITE_GROQ_API_KEY: settings.value.VITE_GROQ_API_KEY,
         VITE_GOOGLE_API_KEY: settings.value.VITE_GOOGLE_API_KEY,
         sttProvider: settings.value.sttProvider,
@@ -813,6 +841,7 @@ export const useSettingsStore = defineStore('settings', () => {
         lmStudioBaseUrl: settings.value.lmStudioBaseUrl,
         zaiBaseUrl: settings.value.zaiBaseUrl,
         minimaxBaseUrl: settings.value.minimaxBaseUrl,
+        deepseekBaseUrl: settings.value.deepseekBaseUrl,
         assistantModel: settings.value.assistantModel,
         assistantSystemPrompt: settings.value.assistantSystemPrompt,
         assistantTemperature: settings.value.assistantTemperature,
@@ -926,6 +955,19 @@ export const useSettingsStore = defineStore('settings', () => {
       if (!currentConfigForTest.minimaxBaseUrl?.trim()) {
         error.value = `Essential setting '${settingKeyToLabelMap.minimaxBaseUrl}' is missing.`
         generalStore.statusMessage = 'MiniMax Base URL is required.'
+        isSaving.value = false
+        return
+      }
+    } else if (currentConfigForTest.aiProvider === 'deepseek') {
+      if (!currentConfigForTest.VITE_DEEPSEEK_API_KEY?.trim()) {
+        error.value = `Essential setting '${settingKeyToLabelMap.VITE_DEEPSEEK_API_KEY}' is missing.`
+        generalStore.statusMessage = 'DeepSeek API Key is required.'
+        isSaving.value = false
+        return
+      }
+      if (!currentConfigForTest.deepseekBaseUrl?.trim()) {
+        error.value = `Essential setting '${settingKeyToLabelMap.deepseekBaseUrl}' is missing.`
+        generalStore.statusMessage = 'DeepSeek Base URL is required.'
         isSaving.value = false
         return
       }
@@ -1047,6 +1089,7 @@ export const useSettingsStore = defineStore('settings', () => {
     VITE_OPENROUTER_API_KEY: string
     VITE_ZAI_API_KEY?: string
     VITE_MINIMAX_API_KEY?: string
+    VITE_DEEPSEEK_API_KEY?: string
     sttProvider: 'openai' | 'groq' | 'google' | 'local'
     ttsProvider?: 'openai' | 'google' | 'local'
     embeddingProvider?: 'openai' | 'local'
@@ -1059,6 +1102,7 @@ export const useSettingsStore = defineStore('settings', () => {
     lmStudioBaseUrl?: string
     zaiBaseUrl?: string
     minimaxBaseUrl?: string
+    deepseekBaseUrl?: string
     useLocalModels?: boolean
     localSttLanguage?: string
   }) {
@@ -1068,6 +1112,8 @@ export const useSettingsStore = defineStore('settings', () => {
     settings.value.VITE_ZAI_API_KEY = onboardingData.VITE_ZAI_API_KEY || ''
     settings.value.VITE_MINIMAX_API_KEY =
       onboardingData.VITE_MINIMAX_API_KEY || ''
+    settings.value.VITE_DEEPSEEK_API_KEY =
+      onboardingData.VITE_DEEPSEEK_API_KEY || ''
     settings.value.sttProvider = onboardingData.sttProvider
     settings.value.aiProvider = onboardingData.aiProvider
     settings.value.VITE_GROQ_API_KEY = onboardingData.VITE_GROQ_API_KEY
@@ -1107,6 +1153,9 @@ export const useSettingsStore = defineStore('settings', () => {
     }
     if (onboardingData.minimaxBaseUrl) {
       settings.value.minimaxBaseUrl = onboardingData.minimaxBaseUrl
+    }
+    if (onboardingData.deepseekBaseUrl) {
+      settings.value.deepseekBaseUrl = onboardingData.deepseekBaseUrl
     }
 
     settings.value.onboardingCompleted = true


### PR DESCRIPTION
## Summary
- Add DeepSeek as an OpenAI-compatible chat inference provider.
- Wire DeepSeek API key/base URL settings into core settings, onboarding, model discovery, and chat routing.
- Add DeepSeek model/catalog coverage and adapter tests, including `thinking: disabled` for tool-call compatibility.

## Validation
- `npm run test -- src/services/llmProviders/__tests__/providerCatalog.test.ts src/services/llmProviders/__tests__/openAICompatible.test.ts src/services/llmProviders/__tests__/deepseek.test.ts`
- `npm run build`
