### PR TITLE
Fix PR build baseline

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -24,8 +24,9 @@ jobs:
     name: Build Check
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest, windows-2022]
 
     steps:
       - name: Checkout Code
@@ -43,7 +44,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: 'npm'
 
       - name: Set up Python (for native modules)
@@ -84,7 +85,7 @@ jobs:
         run: go mod download
 
       - name: Install Node Dependencies
-        run: npm install
+        run: npm ci
         env:
           PYTHON: ${{ steps.setup_python.outputs.python-path }}
           npm_config_python: ${{ steps.setup_python.outputs.python-path }}
@@ -115,7 +116,7 @@ jobs:
       - name: Build Go Backend
         working-directory: backend
         run: |
-          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+          if [[ "${{ matrix.os }}" == "windows-2022" ]]; then
             go build -ldflags="-s -w" -o ../resources/backend/alice-backend.exe
           else
             go build -ldflags="-s -w" -o ../resources/backend/alice-backend


### PR DESCRIPTION
## Summary
- move the PR build matrix from Node 18 to Node 22
- pin the Windows PR runner to `windows-2022`
- disable matrix fail-fast so all OS jobs report their own result
- use `npm ci` for reproducible dependency installs

## Why
Dependabot PR builds were failing because newer npm packages require Node 20+ while the workflow still installed Node 18. Windows jobs were also landing on a runner image with Visual Studio 18, which the native module toolchain did not recognize while rebuilding `hnswlib-node`.

## Validation
- `npm ci`
- `npm run test`
- `git diff --check`
- parsed `.github/workflows/pr-build.yml` with Ruby YAML
