### PR TITLE
Refresh non-OpenAI provider integrations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "electron-log": "^5.4.3",
         "electron-updater": "6.8.9",
         "googleapis": "^166.0.0",
-        "groq-sdk": "^1.3.0",
+        "groq-sdk": "^1.5.0",
         "hnswlib-node": "^3.0.0",
         "mammoth": "^1.12.0",
         "marked": "^15.0.11",
@@ -5376,9 +5376,9 @@
       "license": "ISC"
     },
     "node_modules/groq-sdk": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/groq-sdk/-/groq-sdk-1.3.0.tgz",
-      "integrity": "sha512-mvgUIpAxlk/VxWIoliHx4R+Ha78Bd/g0t24OFjCXtdLbNiY1rW4h9AcznKBwFho7K/Nq732ZSjxMYkNb1xeCFg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/groq-sdk/-/groq-sdk-1.5.0.tgz",
+      "integrity": "sha512-aa5yaMVd8kehBacU3Pp7roObOuPksZNau+nPW+GDDB7OV/8jybVzeeOv54lZj8owNNIc3a7Tu2eYI7/kIwtMNw==",
       "license": "Apache-2.0",
       "bin": {
         "groq-sdk": "bin/cli"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "electron-log": "^5.4.3",
     "electron-updater": "6.8.9",
     "googleapis": "^166.0.0",
-    "groq-sdk": "^1.3.0",
+    "groq-sdk": "^1.5.0",
     "hnswlib-node": "^3.0.0",
     "mammoth": "^1.12.0",
     "marked": "^15.0.11",

--- a/src/services/__tests__/apiService.test.ts
+++ b/src/services/__tests__/apiService.test.ts
@@ -1,0 +1,23 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { transcribeWithGoogle } from '../apiService'
+import { useSettingsStore } from '../../stores/settingsStore'
+import { float32ArrayToWav } from '../../utils/audioProcess'
+
+describe('transcribeWithGoogle', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    useSettingsStore().updateSetting('VITE_GOOGLE_API_KEY', 'test-key')
+  })
+
+  it('rejects recordings longer than Google synchronous recognition allows', async () => {
+    const overlongRecording = float32ArrayToWav(
+      new Float32Array(16000 * 60 + 1),
+      16000
+    )
+
+    await expect(transcribeWithGoogle(overlongRecording)).rejects.toThrow(
+      'Google STT only supports recordings up to 60 seconds'
+    )
+  })
+})

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -406,6 +406,27 @@ function mapLanguageToBCP47(isoCode: string): string {
   return mapping[isoCode] || isoCode
 }
 
+const GOOGLE_SYNC_RECOGNITION_MAX_DURATION_SECONDS = 60
+
+function getWavDurationSeconds(audioBuffer: ArrayBuffer): number | null {
+  const view = new DataView(audioBuffer)
+  let offset = 12
+
+  while (offset + 8 <= view.byteLength) {
+    const chunkId = view.getUint32(offset, false)
+    const chunkSize = view.getUint32(offset + 4, true)
+
+    if (chunkId === 0x64617461) {
+      const bytesPerSecond = view.getUint32(28, true)
+      return bytesPerSecond > 0 ? chunkSize / bytesPerSecond : null
+    }
+
+    offset += 8 + chunkSize + (chunkSize % 2)
+  }
+
+  return null
+}
+
 export const transcribeWithGoogle = async (
   audioBuffer: ArrayBuffer
 ): Promise<string> => {
@@ -414,6 +435,16 @@ export const transcribeWithGoogle = async (
 
   if (!apiKey) {
     throw new Error('Google API Key is not configured')
+  }
+
+  const durationSeconds = getWavDurationSeconds(audioBuffer)
+  if (
+    durationSeconds !== null &&
+    durationSeconds > GOOGLE_SYNC_RECOGNITION_MAX_DURATION_SECONDS
+  ) {
+    throw new Error(
+      'Google STT only supports recordings up to 60 seconds. Please retry with a shorter utterance.'
+    )
   }
 
   // Convert ArrayBuffer to Base64 using FileReader (more efficient for large files)

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -445,6 +445,7 @@ export const transcribeWithGoogle = async (
         config: {
           // If we don't specify encoding, Google attempts to detect it from the header (WAV)
           languageCode: languageCode,
+          model: 'latest_short',
         },
         audio: {
           content: base64Audio,

--- a/src/services/llmProviders/__tests__/minimax.test.ts
+++ b/src/services/llmProviders/__tests__/minimax.test.ts
@@ -12,7 +12,11 @@ describe('MiniMax model listing', () => {
       success: true,
       status: 200,
       data: {
-        data: [{ id: 'MiniMax-M2.7' }, { id: 'unrelated-model' }],
+        data: [
+          { id: 'MiniMax-M2.7' },
+          { id: 'MiniMax-M2.5' },
+          { id: 'unrelated-model' },
+        ],
       },
     })
     ;(globalThis as any).window = {
@@ -26,7 +30,10 @@ describe('MiniMax model listing', () => {
       'https://api.minimax.io/v1/'
     )
 
-    expect(models.map(model => model.id)).toEqual(['MiniMax-M2.7'])
+    expect(models.map(model => model.id)).toEqual([
+      'MiniMax-M2.5',
+      'MiniMax-M2.7',
+    ])
     expect(request).toHaveBeenCalledWith(
       expect.objectContaining({
         url: 'https://api.minimax.io/v1/models',

--- a/src/services/llmProviders/__tests__/openAICompatible.test.ts
+++ b/src/services/llmProviders/__tests__/openAICompatible.test.ts
@@ -110,7 +110,7 @@ describe('createOpenAICompatibleResponse', () => {
 
     expect(create).toHaveBeenCalledWith(
       expect.objectContaining({
-        model: 'glm-5.1',
+        model: 'glm-5.2',
       }),
       expect.any(Object)
     )

--- a/src/services/llmProviders/__tests__/openrouter.test.ts
+++ b/src/services/llmProviders/__tests__/openrouter.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { useSettingsStore } from '../../../stores/settingsStore'
+import { getOpenRouterClient } from '../../apiClients'
+import { createOpenRouterResponse } from '../openrouter'
+
+vi.mock('../../apiClients', () => ({
+  getOpenRouterClient: vi.fn(),
+}))
+
+function installWindowMocks() {
+  ;(globalThis as any).window = {
+    customToolsAPI: {
+      list: vi.fn().mockResolvedValue({
+        success: true,
+        data: {
+          tools: [],
+          diagnostics: [],
+          filePath: '',
+          lastModified: Date.now(),
+        },
+      }),
+    },
+  }
+}
+
+describe('createOpenRouterResponse', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    installWindowMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete (globalThis as any).window
+  })
+
+  it('uses the configured model and the OpenRouter web search server tool', async () => {
+    const settingsStore = useSettingsStore()
+    settingsStore.updateSetting('aiProvider', 'openrouter')
+    settingsStore.updateSetting('assistantModel', 'anthropic/claude-sonnet-4.5')
+
+    const create = vi.fn().mockResolvedValue({ choices: [] })
+    vi.mocked(getOpenRouterClient).mockReturnValue({
+      chat: { completions: { create } },
+    } as any)
+
+    await createOpenRouterResponse(
+      [
+        {
+          role: 'user',
+          content: [{ type: 'input_text', text: 'What changed today?' }],
+        } as any,
+      ],
+      null,
+      false
+    )
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'anthropic/claude-sonnet-4.5',
+        max_tool_calls: 1,
+        tools: expect.arrayContaining([
+          { type: 'openrouter:web_search' },
+        ]),
+      }),
+      expect.any(Object)
+    )
+  })
+})

--- a/src/services/llmProviders/__tests__/providerCatalog.test.ts
+++ b/src/services/llmProviders/__tests__/providerCatalog.test.ts
@@ -11,29 +11,39 @@ import {
 describe('providerCatalog', () => {
   it('exposes Z.ai Coding Plan models with API model ids', () => {
     expect(getStaticModelsForProvider('zai').map(model => model.id)).toEqual([
+      'glm-5.2',
       'glm-5.1',
       'glm-5-turbo',
       'glm-4.7',
       'glm-4.5-air',
     ])
-    expect(ZAI_CODING_MODELS[0]?.displayName).toBe('GLM-5.1')
+    expect(ZAI_CODING_MODELS[0]?.displayName).toBe('GLM-5.2')
   })
 
   it('falls back to the Z.ai default for non-coding model ids', () => {
-    expect(getSafeProviderModel('zai', 'gpt-4o-mini')).toBe('glm-5.1')
+    expect(getSafeProviderModel('zai', 'gpt-4o-mini')).toBe('glm-5.2')
+    expect(getSafeProviderModel('zai', 'glm-5.2')).toBe('glm-5.2')
     expect(getSafeProviderModel('zai', 'glm-5-turbo')).toBe('glm-5-turbo')
   })
 
   it('exposes MiniMax text models with API model ids', () => {
     expect(
       getStaticModelsForProvider('minimax').map(model => model.id)
-    ).toEqual(['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'])
+    ).toEqual([
+      'MiniMax-M3',
+      'MiniMax-M2.7',
+      'MiniMax-M2.7-highspeed',
+      'MiniMax-M2.5',
+      'MiniMax-M2.5-highspeed',
+    ])
     expect(MINIMAX_TEXT_MODELS[0]?.displayName).toBe('MiniMax M3')
   })
 
   it('falls back to the MiniMax default for non-MiniMax model ids', () => {
     expect(getSafeProviderModel('minimax', 'gpt-4o-mini')).toBe('MiniMax-M3')
-    expect(getSafeProviderModel('minimax', 'MiniMax-M2.5')).toBe('MiniMax-M3')
+    expect(getSafeProviderModel('minimax', 'MiniMax-M2.5')).toBe(
+      'MiniMax-M2.5'
+    )
   })
 
   it('exposes DeepSeek text models with current API model ids', () => {

--- a/src/services/llmProviders/__tests__/tools.test.ts
+++ b/src/services/llmProviders/__tests__/tools.test.ts
@@ -48,6 +48,7 @@ describe('buildToolsForProvider', () => {
   it('uses OpenRouter server-side web search instead of the Tavily function', async () => {
     const settingsStore = useSettingsStore()
     settingsStore.updateSetting('aiProvider', 'openrouter')
+    settingsStore.updateSetting('assistantTools', ['perform_web_search'])
 
     const { buildToolsForProvider } = await import('../tools')
     const tools = await buildToolsForProvider()

--- a/src/services/llmProviders/__tests__/tools.test.ts
+++ b/src/services/llmProviders/__tests__/tools.test.ts
@@ -44,4 +44,17 @@ describe('buildToolsForProvider', () => {
       partial_images: 2,
     })
   })
+
+  it('uses OpenRouter server-side web search instead of the Tavily function', async () => {
+    const settingsStore = useSettingsStore()
+    settingsStore.updateSetting('aiProvider', 'openrouter')
+
+    const { buildToolsForProvider } = await import('../tools')
+    const tools = await buildToolsForProvider()
+
+    expect(tools).toContainEqual({ type: 'openrouter:web_search' })
+    expect(tools).not.toContainEqual(
+      expect.objectContaining({ name: 'perform_web_search' })
+    )
+  })
 })

--- a/src/services/llmProviders/openrouter.ts
+++ b/src/services/llmProviders/openrouter.ts
@@ -152,7 +152,7 @@ export const createOpenRouterResponse = async (
   if (customInstructions) {
     const openrouterSystemPrompt =
       customInstructions +
-      '\n\nIMPORTANT: You have built-in web search capabilities. When you need to search the web or get current information, you can directly search without using any tools. Do NOT use open_path or other tools for web searches.'
+      '\n\nIMPORTANT: Use the OpenRouter web search tool when you need current information. Do NOT use open_path or other tools for web searches.'
 
     const systemIndex = messages.findIndex(msg => msg.role === 'system')
     if (systemIndex === -1) {
@@ -166,7 +166,7 @@ export const createOpenRouterResponse = async (
         customInstructions.trim() &&
         existing.includes(customInstructions.trim())
       const hasNote = existing.includes(
-        'IMPORTANT: You have built-in web search capabilities.'
+        'IMPORTANT: Use the OpenRouter web search tool when you need current information.'
       )
       let merged = existing
       if (!hasCustom) {
@@ -175,19 +175,16 @@ export const createOpenRouterResponse = async (
           : customInstructions
       }
       if (!hasNote) {
-        merged = `${merged}\n\nIMPORTANT: You have built-in web search capabilities. When you need to search the web or get current information, you can directly search without using any tools. Do NOT use open_path or other tools for web searches.`
+        merged = `${merged}\n\nIMPORTANT: Use the OpenRouter web search tool when you need current information. Do NOT use open_path or other tools for web searches.`
       }
       messages[systemIndex].content = merged.trim()
     }
   }
 
-  const openrouterModel = settings.assistantModel || 'gpt-4.1-mini'
-  const modelWithWebSearch = openrouterModel.includes(':online')
-    ? openrouterModel
-    : `${openrouterModel}:online`
-
-  const params: OpenAI.Chat.ChatCompletionCreateParams = {
-    model: modelWithWebSearch,
+  const params: OpenAI.Chat.ChatCompletionCreateParams & {
+    max_tool_calls?: number
+  } = {
+    model: settings.assistantModel || 'gpt-4.1-mini',
     messages: messages,
     ...(!settings.assistantModel.startsWith('gpt-5')
       ? {
@@ -211,6 +208,8 @@ export const createOpenRouterResponse = async (
             return tool
           })
         : undefined,
+    // OpenRouter server tools can otherwise take up to 30 tool steps per request.
+    max_tool_calls: 1,
     stream: stream,
   }
 

--- a/src/services/llmProviders/providerCatalog.ts
+++ b/src/services/llmProviders/providerCatalog.ts
@@ -22,6 +22,7 @@ export interface ProviderModelDefinition {
 }
 
 export const ZAI_CODING_MODELS: ProviderModelDefinition[] = [
+  { id: 'glm-5.2', displayName: 'GLM-5.2' },
   { id: 'glm-5.1', displayName: 'GLM-5.1' },
   { id: 'glm-5-turbo', displayName: 'GLM-5-Turbo' },
   { id: 'glm-4.7', displayName: 'GLM-4.7' },
@@ -32,6 +33,8 @@ export const MINIMAX_TEXT_MODELS: ProviderModelDefinition[] = [
   { id: 'MiniMax-M3', displayName: 'MiniMax M3' },
   { id: 'MiniMax-M2.7', displayName: 'MiniMax M2.7' },
   { id: 'MiniMax-M2.7-highspeed', displayName: 'MiniMax M2.7 Highspeed' },
+  { id: 'MiniMax-M2.5', displayName: 'MiniMax M2.5' },
+  { id: 'MiniMax-M2.5-highspeed', displayName: 'MiniMax M2.5 Highspeed' },
 ]
 
 export const DEEPSEEK_TEXT_MODELS: ProviderModelDefinition[] = [
@@ -73,7 +76,7 @@ export const PROVIDER_CONFIGS: Record<AIProviderKey, ProviderConfig> = {
   },
   zai: {
     displayName: 'Z.ai',
-    defaultModel: 'glm-5.1',
+    defaultModel: 'glm-5.2',
     nativeWebSearch: false,
   },
   minimax: {

--- a/src/services/llmProviders/tools.ts
+++ b/src/services/llmProviders/tools.ts
@@ -97,7 +97,8 @@ export async function buildToolsForProvider(): Promise<any[]> {
       .filter(tool => {
         if (
           tool.type === 'image_generation' ||
-          tool.type === 'web_search_preview'
+          tool.type === 'web_search_preview' ||
+          tool.name === 'perform_web_search'
         ) {
           return false
         }
@@ -115,6 +116,7 @@ export async function buildToolsForProvider(): Promise<any[]> {
         }
         return tool
       })
+    allowedTools.push({ type: 'openrouter:web_search' })
     finalToolsForApi.length = 0
     finalToolsForApi.push(...allowedTools)
   } else if (!PROVIDER_CONFIGS[settings.aiProvider].nativeWebSearch) {


### PR DESCRIPTION
## What changed

- Add GLM-5.2 as the Z.ai default and expose MiniMax M2.5 variants.
- Replace OpenRouter's deprecated `:online` suffix with the `openrouter:web_search` server tool, capped at one tool call per request.
- Use Google Speech-to-Text's `latest_short` model for short voice inputs.
- Upgrade `groq-sdk` to 1.5.0.

## Why

Keeps provider catalogs, APIs, and SDKs aligned with their supported integrations while maintaining predictable OpenRouter web-search cost and latency.

## Validation

- `npm test` — 126 tests passed
- Focused OpenRouter test passed
- `npx vue-tsc --noEmit`
- `npm run build:web`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for MiniMax M2.5 and M2.5 Highspeed models.
  * Updated Z.ai’s default model to GLM-5.2.
  * OpenRouter now uses built-in web search for current information.
  * Limited OpenRouter web-search tool calls for improved response control.
  * Speech recognition now uses the latest short-form recognition model.

* **Bug Fixes**
  * Prevented legacy web-search tools from being exposed alongside OpenRouter search.
  * Recordings longer than 60 seconds are now rejected before transcription.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->